### PR TITLE
fix: resolve 6 installer bugs identified in test spec review

### DIFF
--- a/scripts/sherpa_install.sh
+++ b/scripts/sherpa_install.sh
@@ -15,10 +15,11 @@
 #   - Port 8000 available
 #
 # Usage:
-#   sudo ./sherpa_install.sh --db-pass "YourPassword"
-#   # OR
 #   export SHERPA_DB_PASSWORD="YourPassword"
 #   sudo -E ./sherpa_install.sh
+#
+#   # Or install a specific version:
+#   sudo -E ./sherpa_install.sh --version v0.3.4
 #
 ################################################################################
 
@@ -198,7 +199,16 @@ check_curl_installed() {
 
 check_port_available() {
     print_info "Checking if port ${DB_PORT} is available..."
-    
+
+    # If the sherpa-db container itself holds the port, that's fine — the installer
+    # will stop and recreate it later. Only fail for other processes.
+    if command -v docker >/dev/null 2>&1; then
+        if docker ps --format '{{.Names}} {{.Ports}}' 2>/dev/null | grep -q "^${CONTAINER_NAME} .*:${DB_PORT}->"; then
+            print_info "Port ${DB_PORT} is held by existing ${CONTAINER_NAME} container (will be replaced)"
+            return 0
+        fi
+    fi
+
     # Check if port is in use (works on most Linux systems)
     if command -v ss >/dev/null 2>&1; then
         if ss -tuln | grep -q ":${DB_PORT} "; then
@@ -223,7 +233,7 @@ check_port_available() {
     else
         print_warning "Cannot verify port availability (ss/netstat not found)"
     fi
-    
+
     print_success "Port ${DB_PORT} is available"
 }
 
@@ -363,9 +373,20 @@ get_server_ip() {
         SERVER_IP="${SERVER_IP:-0.0.0.0}"
     fi
 
-    # Basic validation: check it looks like an IPv4 address
+    # Trim whitespace
+    SERVER_IP="$(echo "$SERVER_IP" | xargs)"
+
+    # Validate IPv4 address format
     if ! echo "$SERVER_IP" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$'; then
         print_error "Invalid IPv4 address: ${SERVER_IP}"
+        exit 1
+    fi
+
+    # Validate each octet is 0-255
+    local IFS='.'
+    read -r o1 o2 o3 o4 <<< "$SERVER_IP"
+    if [ "$o1" -gt 255 ] || [ "$o2" -gt 255 ] || [ "$o3" -gt 255 ] || [ "$o4" -gt 255 ] 2>/dev/null; then
+        print_error "Invalid IPv4 address: ${SERVER_IP} (each octet must be 0-255)"
         exit 1
     fi
 
@@ -386,6 +407,13 @@ setup_sherpa_user() {
         print_success "Created sherpa user"
     else
         print_info "Sherpa user already exists"
+        # Ensure system user has nologin shell (may differ if user was created manually)
+        local current_shell
+        current_shell=$(getent passwd sherpa | cut -d: -f7)
+        if [ "$current_shell" != "/usr/sbin/nologin" ] && [ "$(id -u sherpa)" -lt 1000 ]; then
+            usermod -s /usr/sbin/nologin sherpa
+            print_info "Updated sherpa shell to /usr/sbin/nologin (was: ${current_shell})"
+        fi
     fi
     
     # Add sherpa user to required groups
@@ -978,12 +1006,14 @@ cleanup_on_error() {
     if [ $exit_code -ne 0 ]; then
         print_error "Installation failed (exit code: ${exit_code})"
         
-        # Stop and remove container if it exists
-        if docker ps -a --format '{{.Names}}' | grep -q "^${CONTAINER_NAME}$" 2>/dev/null; then
-            print_info "Cleaning up container..."
-            docker stop "${CONTAINER_NAME}" 2>/dev/null || true
-            docker rm "${CONTAINER_NAME}" 2>/dev/null || true
-            print_info "Container removed"
+        # Stop and remove container if docker is available and the container exists
+        if command -v docker >/dev/null 2>&1; then
+            if docker ps -a --format '{{.Names}}' 2>/dev/null | grep -q "^${CONTAINER_NAME}$"; then
+                print_info "Cleaning up container..."
+                docker stop "${CONTAINER_NAME}" 2>/dev/null || true
+                docker rm "${CONTAINER_NAME}" 2>/dev/null || true
+                print_info "Container removed"
+            fi
         fi
         
         echo ""
@@ -1040,10 +1070,10 @@ main() {
     print_info "Starting installation..."
     echo ""
 
+    check_port_available
     install_system_packages
     enable_libvirtd
     install_docker
-    check_port_available
     setup_sherpa_user
     setup_directories
     stop_existing_container

--- a/test-scripts/install_tests.bats
+++ b/test-scripts/install_tests.bats
@@ -300,11 +300,23 @@ _source() {
 }
 
 @test "check_port_available: fails when target port is already in use" {
-    # Bind a random high port, then tell the script that is DB_PORT
+    # Bind a random high port, then tell the script that is DB_PORT.
+    # Use Python to open a TCP socket — works regardless of which nc variant
+    # is installed (OpenBSD nc vs GNU netcat have incompatible flags).
     local test_port=18999
-    # Start a listener in the background
-    bash -c "nc -l -p ${test_port} >/dev/null 2>&1 &"
-    sleep 0.3
+    python3 -c "
+import socket, time, os
+s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+s.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+s.bind(('0.0.0.0', ${test_port}))
+s.listen(1)
+# Write PID so parent can kill us
+with open('/tmp/sherpa_port_test.pid', 'w') as f:
+    f.write(str(os.getpid()))
+# Block until killed
+time.sleep(60)
+" &
+    sleep 0.5
     run bash -c "
         set +e
         source '${STRIPPED_SCRIPT}'
@@ -312,7 +324,8 @@ _source() {
         check_port_available
     "
     # Kill the listener
-    pkill -f "nc -l -p ${test_port}" 2>/dev/null || true
+    kill "$(cat /tmp/sherpa_port_test.pid 2>/dev/null)" 2>/dev/null || true
+    rm -f /tmp/sherpa_port_test.pid
     [ "$status" -eq 1 ]
     [[ "$output" == *"already in use"* ]]
 }
@@ -479,7 +492,7 @@ _source() {
     [[ "$output" == *"Invalid IPv4"* ]]
 }
 
-@test "get_server_ip: rejects an empty string" {
+@test "get_server_ip: rejects an empty / whitespace-only string" {
     run bash -c "
         set +e
         source '${STRIPPED_SCRIPT}'
@@ -487,20 +500,18 @@ _source() {
         get_server_ip
     "
     [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid IPv4"* ]]
 }
 
-@test "get_server_ip: known gap — accepts out-of-range octets (e.g. 999.999.999.999)" {
-    # The regex ^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ does not validate octet range.
-    # This test documents the existing behaviour; it should be updated once
-    # stricter validation is added to the script (see Documentation Bugs in spec).
+@test "get_server_ip: rejects out-of-range octets (e.g. 999.999.999.999)" {
     run bash -c "
         set +e
         source '${STRIPPED_SCRIPT}'
         SERVER_IP='999.999.999.999'
         get_server_ip
     "
-    # Currently passes — this is the known gap, not desired behaviour.
-    [ "$status" -eq 0 ]
+    [ "$status" -eq 1 ]
+    [[ "$output" == *"Invalid IPv4"* ]]
 }
 
 # ============================================================
@@ -702,11 +713,8 @@ _require_container() {
     if [ -z "${SHERPA_DB_PASSWORD:-}" ] || [ -z "${SHERPA_SERVER_IPV4:-}" ]; then
         skip "set SHERPA_DB_PASSWORD and SHERPA_SERVER_IPV4 to run idempotency test"
     fi
-    # Known issue: check_port_available fails when sherpa-db is already running on DB_PORT.
-    # Stop the container first so the port check passes, then re-run (the install restarts it).
-    # See Documentation Bug #6 in the spec.
-    docker stop sherpa-db 2>/dev/null || true
-    docker rm sherpa-db 2>/dev/null || true
+    # check_port_available now detects when sherpa-db owns the port and skips the
+    # error, so no manual container teardown is needed before re-running.
     run bash -c "SHERPA_DB_PASSWORD='${SHERPA_DB_PASSWORD}' SHERPA_SERVER_IPV4='${SHERPA_SERVER_IPV4}' bash '${SCRIPT}'"
     [ "$status" -eq 0 ]
 }

--- a/test-specs/install/sherpa-install.md
+++ b/test-specs/install/sherpa-install.md
@@ -76,9 +76,7 @@
 - Rejects a hostname (e.g., "myserver.example.com") `[unit]` **P0**
 - Rejects an empty / whitespace-only string `[unit]` **P1**
 - Defaults to 0.0.0.0 when no input provided `[manual]` **P1**
-- Known gap: accepts out-of-range octets (e.g. `999.999.999.999`) `[unit]` **P1** *(documents existing behaviour — should fail once fixed)*
-
-**Known issue:** Regex `^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$` accepts invalid octets like `999.999.999.999`. Consider adding octet range validation.
+- Rejects out-of-range octets (e.g. `999.999.999.999`) `[unit]` **P1**
 
 ---
 
@@ -199,14 +197,14 @@
 
 ---
 
-## Documentation Bugs
+## Documentation Bugs (resolved)
 
-These are not test cases but issues found during review:
+These issues were found during review and have been fixed:
 
-1. **Dead `--db-pass` flag**: Header comment (line 18) mentions `--db-pass` but the arg parser (lines 1006-1022) only handles `--version` and `--help`. The env var `SHERPA_DB_PASSWORD` works, but the CLI flag does not exist.
-2. **Weak IPv4 validation**: Regex `^[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$` accepts `999.999.999.999`. Should validate each octet is 0-255.
-3. **Password complexity gap**: Script only checks length (>= 8 chars). The Rust-side `validate_password_strength()` requires uppercase, lowercase, and special characters. Consider aligning the two.
-4. **Port check ordering**: `check_port_available` runs after `install_system_packages` and `install_docker`. If Docker or another package binds the target port, the user has already waited through a long apt install before being told the port is in use. Consider moving the port check to pre-flight.
-5. **`cleanup_on_error` calls `docker` without a guard**: When the install fails before Docker is installed (e.g., at the Ubuntu version check), `cleanup_on_error` runs `docker ps -a ...` which prints `docker: command not found` to stderr. The `2>/dev/null` on the pipe only silences `grep`'s stderr, not `docker`'s. Fix: add `2>/dev/null` to the `docker ps` call itself, or guard with `command -v docker >/dev/null 2>&1`.
-6. **`check_port_available` breaks idempotent re-runs**: When sherpa-db is already running and bound to `DB_PORT`, a second invocation of the installer fails at `check_port_available` before it can reach `stop_existing_container`. The fix is to check whether the port is held by the sherpa-db container itself and skip the error in that case (or move `stop_existing_container` before the port check).
-7. **`setup_sherpa_user` does not enforce shell on existing user**: If a user named `sherpa` already exists (e.g., as a regular login user with `/bin/bash`), the script detects the existing account and skips user creation, leaving the shell unchanged. On a fresh install the system user is created with `/usr/sbin/nologin`. Consider adding a check to update the shell if the existing account has an interactive shell.
+1. ~~**Dead `--db-pass` flag**: Header comment mentioned `--db-pass` but the arg parser only handles `--version` and `--help`.~~ **Fixed** — comment updated to show correct usage.
+2. ~~**Weak IPv4 validation**: Regex accepted `999.999.999.999`.~~ **Fixed** — added octet range validation (0-255).
+3. **Password complexity gap**: Script only checks length (>= 8 chars). The Rust-side `validate_password_strength()` requires uppercase, lowercase, and special characters. Consider aligning the two. *(Deferred — requires a design decision on whether to enforce complexity in the installer.)*
+4. ~~**Port check ordering**: `check_port_available` ran after `install_system_packages` and `install_docker`.~~ **Fixed** — moved to pre-flight, before package installation.
+5. ~~**`cleanup_on_error` calls `docker` without a guard**.~~ **Fixed** — guarded with `command -v docker >/dev/null 2>&1`.
+6. ~~**`check_port_available` breaks idempotent re-runs**.~~ **Fixed** — when sherpa-db container owns the port, the check passes and the container is replaced later.
+7. ~~**`setup_sherpa_user` does not enforce shell on existing user**.~~ **Fixed** — system users (uid < 1000) now get their shell updated to `/usr/sbin/nologin` if it differs.


### PR DESCRIPTION
- Fix dead --db-pass reference in header comment
- Add IPv4 octet range validation (0-255) with whitespace trimming
- Move port check to pre-flight (before apt install)
- Guard cleanup_on_error docker calls with command -v check
- Allow idempotent re-runs when sherpa-db already holds the port
- Enforce nologin shell on existing system sherpa user (uid < 1000)
- Fix port test to use python3 socket instead of nc (OpenBSD compat)