### PR TITLE
fix: secure SSH private keys on Windows

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -107,3 +107,21 @@ jobs:
         with:
           name: coverage-report
           path: lcov.info
+
+  windows-client:
+    name: Windows Client
+    runs-on: windows-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+        with:
+          components: clippy
+
+      - name: Run client clippy
+        run: cargo clippy -p sherpa -- -D warnings
+
+      - name: Test native private key permissions
+        run: cargo test -p sherpa private_key::tests

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,7 +988,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "container"
-version = "0.3.75"
+version = "0.3.76"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1204,7 +1204,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "db"
-version = "0.3.75"
+version = "0.3.76"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "libvirt"
-version = "0.3.75"
+version = "0.3.76"
 dependencies = [
  "anyhow",
  "askama",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "network"
-version = "0.3.75"
+version = "0.3.76"
 dependencies = [
  "anyhow",
  "aya",
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "0.3.75"
+version = "0.3.76"
 dependencies = [
  "anyhow",
  "argon2",
@@ -4883,7 +4883,7 @@ dependencies = [
 
 [[package]]
 name = "sherpa"
-version = "0.3.75"
+version = "0.3.76"
 dependencies = [
  "anyhow",
  "askama",
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "sherpad"
-version = "0.3.75"
+version = "0.3.76"
 dependencies = [
  "anyhow",
  "askama",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "template"
-version = "0.3.75"
+version = "0.3.76"
 dependencies = [
  "anyhow",
  "askama",
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "topology"
-version = "0.3.75"
+version = "0.3.76"
 dependencies = [
  "anyhow",
  "serde",
@@ -6195,7 +6195,7 @@ dependencies = [
 
 [[package]]
 name = "validate"
-version = "0.3.75"
+version = "0.3.76"
 dependencies = [
  "anyhow",
  "shared",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4914,6 +4914,7 @@ dependencies = [
  "url",
  "uuid",
  "validate",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sherpa"
-version = "0.3.75"
+version = "0.3.76"
 edition = "2024"
 
 [dependencies]

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -68,5 +68,13 @@ rustls-native-certs = "0.8"
 # Home directory detection
 dirs = "6.0"
 
+[target.'cfg(windows)'.dependencies]
+windows-sys = { version = "0.61.2", features = [
+  "Win32_Foundation",
+  "Win32_Security",
+  "Win32_Security_Authorization",
+  "Win32_System_Threading",
+] }
+
 [dev-dependencies]
 tempfile = "3.25.0"

--- a/crates/client/src/cmd/download.rs
+++ b/crates/client/src/cmd/download.rs
@@ -4,14 +4,12 @@ use std::time::Duration;
 
 use anyhow::{Context, Result, bail};
 
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
-
 use shared::data::{ClientConfig, DownloadLabResponse};
 use shared::error::RpcErrorCode;
 use shared::konst::{LAB_FILE_NAME, SHERPA_SSH_CONFIG_FILE, SHERPA_SSH_PRIVATE_KEY_FILE};
 use shared::util::{Emoji, add_lab_ssh_include, file_exists, get_cwd, term_msg_surround};
 
+use crate::private_key::write_private_key;
 use crate::token::load_token;
 use crate::ws_client::{RpcRequest, WebSocketClient};
 
@@ -135,26 +133,12 @@ pub async fn download(
     }
 
     // Write SSH private key with 0600 permissions
-    let ssh_key_path = Path::new(&cwd)
-        .join(SHERPA_SSH_PRIVATE_KEY_FILE)
-        .to_string_lossy()
-        .to_string();
-    fs::write(&ssh_key_path, &data.ssh_private_key).context("Failed to write SSH key")?;
-
-    #[cfg(unix)]
-    {
-        if let Err(e) = fs::set_permissions(&ssh_key_path, fs::Permissions::from_mode(0o600)) {
-            println!(
-                "\n{} Warning: Failed to set permissions on SSH key: {}",
-                Emoji::Warning,
-                e
-            );
-        }
-    }
+    let ssh_key_path = Path::new(&cwd).join(SHERPA_SSH_PRIVATE_KEY_FILE);
+    write_private_key(&ssh_key_path, &data.ssh_private_key).context("Failed to write SSH key")?;
     println!(
         "{} SSH private key created: {}",
         Emoji::Success,
-        ssh_key_path
+        ssh_key_path.display()
     );
 
     // Write lab-info.toml

--- a/crates/client/src/cmd/ssh.rs
+++ b/crates/client/src/cmd/ssh.rs
@@ -1,9 +1,12 @@
+use std::path::Path;
 use std::process::Command;
 
-use anyhow::Result;
+use anyhow::{Context, Result};
 
-use shared::konst::SHERPA_SSH_CONFIG_FILE;
+use shared::konst::{SHERPA_SSH_CONFIG_FILE, SHERPA_SSH_PRIVATE_KEY_FILE};
 use shared::util::term_msg_surround;
+
+use crate::private_key::restrict_private_key_permissions;
 
 /// Qualify a device name with the lab ID suffix if not already present.
 ///
@@ -22,6 +25,9 @@ fn qualify_device_name(name: &str, lab_id: &str) -> String {
 pub async fn ssh(name: &str, lab_id: &str) -> Result<()> {
     let qualified_name = qualify_device_name(name, lab_id);
     term_msg_surround(&format!("Connecting to: {qualified_name}"));
+
+    restrict_private_key_permissions(Path::new(SHERPA_SSH_PRIVATE_KEY_FILE))
+        .context("Failed to secure SSH private key before connecting")?;
 
     let status = Command::new("ssh")
         .arg(&qualified_name)

--- a/crates/client/src/cmd/up.rs
+++ b/crates/client/src/cmd/up.rs
@@ -4,9 +4,6 @@ use std::fs;
 use std::path::Path;
 use std::time::Duration;
 
-#[cfg(unix)]
-use std::os::unix::fs::PermissionsExt;
-
 use shared::data::{ClientConfig, StatusKind, StatusMessage, UpResponse};
 use shared::error::RpcErrorCode;
 use shared::konst::{LAB_FILE_NAME, SHERPA_SSH_CONFIG_FILE, SHERPA_SSH_PRIVATE_KEY_FILE};
@@ -16,6 +13,7 @@ use shared::util::{
 };
 use topology::StartupScript;
 
+use crate::private_key::write_private_key;
 use crate::token::load_token;
 use crate::ws_client::{RpcRequest, WebSocketClient};
 
@@ -241,30 +239,13 @@ pub async fn up(
     // Write SSH private key to local directory with 0600 permissions
     match get_cwd() {
         Ok(cwd) => {
-            let local_ssh_key_path = Path::new(&cwd)
-                .join(SHERPA_SSH_PRIVATE_KEY_FILE)
-                .to_string_lossy()
-                .to_string();
-            match fs::write(&local_ssh_key_path, &up_data.ssh_private_key) {
+            let local_ssh_key_path = Path::new(&cwd).join(SHERPA_SSH_PRIVATE_KEY_FILE);
+            match write_private_key(&local_ssh_key_path, &up_data.ssh_private_key) {
                 Ok(_) => {
-                    // Set Unix permissions to 0600 (owner read/write only)
-                    #[cfg(unix)]
-                    {
-                        if let Err(e) = fs::set_permissions(
-                            &local_ssh_key_path,
-                            fs::Permissions::from_mode(0o600),
-                        ) {
-                            println!(
-                                "\n{} Warning: Failed to set permissions on SSH key: {}",
-                                Emoji::Warning,
-                                e
-                            );
-                        }
-                    }
                     println!(
                         "{} SSH private key created: {}",
                         Emoji::Success,
-                        local_ssh_key_path
+                        local_ssh_key_path.display()
                     );
                 }
                 Err(e) => {

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -1,9 +1,14 @@
 #![deny(clippy::unwrap_used, clippy::expect_used)]
-#![cfg_attr(not(test), forbid(unsafe_code))]
+#![cfg_attr(not(test), deny(unsafe_code))]
 
 mod cmd;
+mod private_key;
 mod token;
 mod ws_client;
+
+#[cfg(windows)]
+#[allow(unsafe_code)]
+mod windows_acl;
 
 use std::process::ExitCode;
 

--- a/crates/client/src/private_key.rs
+++ b/crates/client/src/private_key.rs
@@ -1,0 +1,157 @@
+use std::fs;
+use std::path::Path;
+
+use anyhow::{Context, Result, anyhow, bail};
+
+#[cfg(unix)]
+use std::os::unix::fs::PermissionsExt;
+
+/// Write an SSH private key and restrict it to the current user.
+#[tracing::instrument(level = "debug", skip(contents), fields(path = %path.display()))]
+pub(crate) fn write_private_key(path: &Path, contents: &str) -> Result<()> {
+    write_private_key_with_restriction(path, contents, restrict_private_key_permissions)
+}
+
+fn write_private_key_with_restriction<F>(path: &Path, contents: &str, restrict: F) -> Result<()>
+where
+    F: FnOnce(&Path) -> Result<()>,
+{
+    fs::write(path, contents)
+        .with_context(|| format!("Failed to write SSH private key: {}", path.display()))?;
+
+    if let Err(permission_error) = restrict(path) {
+        return match fs::remove_file(path) {
+            Ok(()) => Err(permission_error
+                .context("Removed SSH private key after permissions could not be secured")),
+            Err(cleanup_error) => Err(anyhow!(
+                "{permission_error:#}; also failed to remove insecure SSH private key {}: {cleanup_error}",
+                path.display()
+            )),
+        };
+    }
+
+    Ok(())
+}
+
+/// Restrict an existing SSH private key to the current user.
+#[tracing::instrument(level = "debug", fields(path = %path.display()))]
+pub(crate) fn restrict_private_key_permissions(path: &Path) -> Result<()> {
+    if !path.is_file() {
+        bail!("SSH private key does not exist: {}", path.display());
+    }
+
+    #[cfg(unix)]
+    {
+        fs::set_permissions(path, fs::Permissions::from_mode(0o600)).with_context(|| {
+            format!(
+                "Failed to restrict SSH private key permissions: {}",
+                path.display()
+            )
+        })?;
+    }
+
+    #[cfg(windows)]
+    {
+        crate::windows_acl::restrict_file_to_current_user(path).with_context(|| {
+            format!(
+                "Failed to restrict SSH private key permissions: {}",
+                path.display()
+            )
+        })?;
+    }
+
+    #[cfg(not(any(unix, windows)))]
+    {
+        bail!("SSH private key permissions are unsupported on this platform");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use std::fs;
+
+    use anyhow::bail;
+
+    #[cfg(unix)]
+    use std::os::unix::fs::PermissionsExt;
+
+    use super::{
+        restrict_private_key_permissions, write_private_key, write_private_key_with_restriction,
+    };
+
+    #[cfg(unix)]
+    #[test]
+    fn write_private_key_sets_owner_only_permissions() {
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let key_path = temp_dir.path().join("sherpa_ssh_key");
+
+        write_private_key(&key_path, "private key").expect("write private key");
+
+        let mode = fs::metadata(&key_path)
+            .expect("read private key metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[cfg(unix)]
+    #[test]
+    fn restrict_private_key_permissions_repairs_existing_file() {
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let key_path = temp_dir.path().join("sherpa_ssh_key");
+        fs::write(&key_path, "private key").expect("write private key");
+        fs::set_permissions(&key_path, fs::Permissions::from_mode(0o644))
+            .expect("set permissive mode");
+
+        restrict_private_key_permissions(&key_path).expect("restrict private key");
+
+        let mode = fs::metadata(&key_path)
+            .expect("read private key metadata")
+            .permissions()
+            .mode()
+            & 0o777;
+        assert_eq!(mode, 0o600);
+    }
+
+    #[test]
+    fn restrict_private_key_permissions_rejects_missing_file() {
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let key_path = temp_dir.path().join("missing_key");
+
+        let error = restrict_private_key_permissions(&key_path)
+            .expect_err("missing private key should fail");
+
+        assert!(error.to_string().contains("SSH private key"));
+    }
+
+    #[test]
+    fn write_private_key_removes_file_when_restriction_fails() {
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let key_path = temp_dir.path().join("sherpa_ssh_key");
+
+        let error = write_private_key_with_restriction(&key_path, "private key", |_| {
+            bail!("permission failure")
+        })
+        .expect_err("permission failure should fail the write");
+
+        assert!(error.to_string().contains("Removed SSH private key"));
+        assert!(!key_path.exists());
+    }
+
+    #[cfg(windows)]
+    #[test]
+    fn write_private_key_sets_current_user_only_acl() {
+        let temp_dir = tempfile::tempdir().expect("create temp directory");
+        let key_path = temp_dir.path().join("sherpa_ssh_key");
+
+        write_private_key(&key_path, "private key").expect("write private key");
+
+        assert!(
+            crate::windows_acl::is_restricted_to_current_user(&key_path)
+                .expect("inspect private key ACL")
+        );
+    }
+}

--- a/crates/client/src/windows_acl.rs
+++ b/crates/client/src/windows_acl.rs
@@ -1,0 +1,274 @@
+use std::io;
+use std::mem::size_of;
+use std::os::windows::ffi::OsStrExt;
+use std::path::Path;
+use std::ptr::{null, null_mut};
+
+use anyhow::{Context, Result, bail};
+use windows_sys::Win32::Foundation::{CloseHandle, GENERIC_ALL, HANDLE, LocalFree};
+use windows_sys::Win32::Security::Authorization::{
+    EXPLICIT_ACCESS_W, NO_MULTIPLE_TRUSTEE, SE_FILE_OBJECT, SET_ACCESS, SetEntriesInAclW,
+    SetNamedSecurityInfoW, TRUSTEE_IS_SID, TRUSTEE_IS_USER, TRUSTEE_W,
+};
+use windows_sys::Win32::Security::{
+    ACL, DACL_SECURITY_INFORMATION, GetTokenInformation, NO_INHERITANCE,
+    PROTECTED_DACL_SECURITY_INFORMATION, PSID, TOKEN_QUERY, TOKEN_USER, TokenUser,
+};
+use windows_sys::Win32::System::Threading::{GetCurrentProcess, OpenProcessToken};
+
+struct OwnedHandle(HANDLE);
+
+impl Drop for OwnedHandle {
+    fn drop(&mut self) {
+        // SAFETY: `self.0` is a valid token handle returned by `OpenProcessToken`
+        // and this type owns it exclusively.
+        unsafe {
+            let _ = CloseHandle(self.0);
+        }
+    }
+}
+
+struct LocalAcl(*mut ACL);
+
+impl Drop for LocalAcl {
+    fn drop(&mut self) {
+        if !self.0.is_null() {
+            // SAFETY: `self.0` was allocated by `SetEntriesInAclW` and has not
+            // been freed elsewhere.
+            unsafe {
+                let _ = LocalFree(self.0.cast());
+            }
+        }
+    }
+}
+
+struct CurrentUserSid {
+    storage: Vec<usize>,
+}
+
+impl CurrentUserSid {
+    fn load() -> Result<Self> {
+        let mut token_handle = null_mut();
+
+        // SAFETY: `token_handle` points to writable storage and the process
+        // pseudo-handle is valid for the duration of this call.
+        let opened =
+            unsafe { OpenProcessToken(GetCurrentProcess(), TOKEN_QUERY, &mut token_handle) };
+        if opened == 0 {
+            return Err(io::Error::last_os_error()).context("Failed to open current process token");
+        }
+        let token = OwnedHandle(token_handle);
+
+        let mut required_bytes = 0u32;
+        // SAFETY: A null buffer with length zero is the documented size-query
+        // form of `GetTokenInformation`.
+        unsafe {
+            let _ = GetTokenInformation(token.0, TokenUser, null_mut(), 0, &mut required_bytes);
+        }
+        if required_bytes == 0 {
+            return Err(io::Error::last_os_error())
+                .context("Failed to determine current user SID size");
+        }
+
+        let word_size = size_of::<usize>();
+        let word_count = (required_bytes as usize).div_ceil(word_size);
+        let mut storage = vec![0usize; word_count];
+
+        // SAFETY: `storage` is aligned for `TOKEN_USER`, has at least
+        // `required_bytes` writable bytes, and remains alive in the returned
+        // value for as long as its embedded SID is used.
+        let loaded = unsafe {
+            GetTokenInformation(
+                token.0,
+                TokenUser,
+                storage.as_mut_ptr().cast(),
+                required_bytes,
+                &mut required_bytes,
+            )
+        };
+        if loaded == 0 {
+            return Err(io::Error::last_os_error()).context("Failed to read current user SID");
+        }
+
+        Ok(Self { storage })
+    }
+
+    fn as_ptr(&self) -> PSID {
+        // SAFETY: `storage` was populated by `GetTokenInformation` for the
+        // `TokenUser` information class and is aligned for `TOKEN_USER`.
+        unsafe {
+            let token_user = &*self.storage.as_ptr().cast::<TOKEN_USER>();
+            token_user.User.Sid
+        }
+    }
+}
+
+/// Replace a file's DACL with a protected entry for the current user only.
+#[tracing::instrument(level = "debug", fields(path = %path.display()))]
+pub(crate) fn restrict_file_to_current_user(path: &Path) -> Result<()> {
+    let current_user = CurrentUserSid::load()?;
+    let user_sid = current_user.as_ptr();
+    if user_sid.is_null() {
+        bail!("Current process token did not contain a user SID");
+    }
+
+    let trustee = TRUSTEE_W {
+        pMultipleTrustee: null_mut(),
+        MultipleTrusteeOperation: NO_MULTIPLE_TRUSTEE,
+        TrusteeForm: TRUSTEE_IS_SID,
+        TrusteeType: TRUSTEE_IS_USER,
+        ptstrName: user_sid.cast(),
+    };
+    let entry = EXPLICIT_ACCESS_W {
+        grfAccessPermissions: GENERIC_ALL,
+        grfAccessMode: SET_ACCESS,
+        grfInheritance: NO_INHERITANCE,
+        Trustee: trustee,
+    };
+
+    let mut acl = null_mut();
+    // SAFETY: `entry` and the SID it references remain valid for this call;
+    // `acl` points to writable output storage and starts null as required when
+    // creating a new ACL.
+    let acl_status = unsafe { SetEntriesInAclW(1, &entry, null(), &mut acl) };
+    if acl_status != 0 {
+        return Err(io::Error::from_raw_os_error(acl_status as i32))
+            .context("Failed to create protected SSH private key ACL");
+    }
+    let acl = LocalAcl(acl);
+
+    let mut wide_path: Vec<u16> = path.as_os_str().encode_wide().collect();
+    if wide_path.contains(&0) {
+        bail!("SSH private key path contains an embedded NUL");
+    }
+    wide_path.push(0);
+
+    // SAFETY: `wide_path` is NUL-terminated and alive for the call; `acl` is a
+    // valid ACL created by `SetEntriesInAclW`. Owner, group, and SACL are null
+    // because the flags request only a protected DACL update.
+    let set_status = unsafe {
+        SetNamedSecurityInfoW(
+            wide_path.as_mut_ptr(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION | PROTECTED_DACL_SECURITY_INFORMATION,
+            null_mut(),
+            null_mut(),
+            acl.0,
+            null(),
+        )
+    };
+    if set_status != 0 {
+        return Err(io::Error::from_raw_os_error(set_status as i32))
+            .context("Failed to apply protected SSH private key ACL");
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+pub(crate) fn is_restricted_to_current_user(path: &Path) -> Result<bool> {
+    use std::ffi::c_void;
+    use std::mem::size_of;
+
+    use windows_sys::Win32::Security::Authorization::GetNamedSecurityInfoW;
+    use windows_sys::Win32::Security::{
+        ACCESS_ALLOWED_ACE, ACL_SIZE_INFORMATION, AclSizeInformation, EqualSid, GetAce,
+        GetAclInformation, GetSecurityDescriptorControl, INHERITED_ACE, PSECURITY_DESCRIPTOR,
+        SE_DACL_PROTECTED,
+    };
+
+    struct LocalSecurityDescriptor(PSECURITY_DESCRIPTOR);
+
+    impl Drop for LocalSecurityDescriptor {
+        fn drop(&mut self) {
+            if !self.0.is_null() {
+                // SAFETY: `self.0` was allocated by `GetNamedSecurityInfoW`
+                // and is owned by this value.
+                unsafe {
+                    let _ = LocalFree(self.0);
+                }
+            }
+        }
+    }
+
+    let current_user = CurrentUserSid::load()?;
+    let mut wide_path: Vec<u16> = path.as_os_str().encode_wide().collect();
+    wide_path.push(0);
+
+    let mut dacl = null_mut();
+    let mut descriptor = null_mut();
+    // SAFETY: `wide_path` is NUL-terminated and the output pointers refer to
+    // writable storage. The returned descriptor is released below.
+    let status = unsafe {
+        GetNamedSecurityInfoW(
+            wide_path.as_mut_ptr(),
+            SE_FILE_OBJECT,
+            DACL_SECURITY_INFORMATION,
+            null_mut(),
+            null_mut(),
+            &mut dacl,
+            null_mut(),
+            &mut descriptor,
+        )
+    };
+    if status != 0 {
+        return Err(io::Error::from_raw_os_error(status as i32))
+            .context("Failed to inspect SSH private key ACL");
+    }
+    let descriptor = LocalSecurityDescriptor(descriptor);
+    if dacl.is_null() || descriptor.0.is_null() {
+        return Ok(false);
+    }
+
+    let mut control = 0u16;
+    let mut revision = 0u32;
+    // SAFETY: `descriptor.0` is a valid security descriptor returned by
+    // `GetNamedSecurityInfoW`; the output pointers are writable.
+    let control_loaded =
+        unsafe { GetSecurityDescriptorControl(descriptor.0, &mut control, &mut revision) };
+    if control_loaded == 0 {
+        return Err(io::Error::last_os_error())
+            .context("Failed to inspect SSH private key ACL protection");
+    }
+    if control & SE_DACL_PROTECTED == 0 {
+        return Ok(false);
+    }
+
+    let mut acl_info = ACL_SIZE_INFORMATION::default();
+    // SAFETY: `dacl` is valid while `descriptor` is alive and `acl_info`
+    // provides correctly sized writable output storage.
+    let acl_loaded = unsafe {
+        GetAclInformation(
+            dacl,
+            (&mut acl_info as *mut ACL_SIZE_INFORMATION).cast(),
+            size_of::<ACL_SIZE_INFORMATION>() as u32,
+            AclSizeInformation,
+        )
+    };
+    if acl_loaded == 0 {
+        return Err(io::Error::last_os_error()).context("Failed to inspect SSH private key ACEs");
+    }
+    if acl_info.AceCount != 1 {
+        return Ok(false);
+    }
+
+    let mut ace: *mut c_void = null_mut();
+    // SAFETY: `dacl` contains one ACE and `ace` points to writable output
+    // storage for the borrowed ACE pointer.
+    let ace_loaded = unsafe { GetAce(dacl, 0, &mut ace) };
+    if ace_loaded == 0 || ace.is_null() {
+        return Err(io::Error::last_os_error()).context("Failed to inspect SSH private key ACE");
+    }
+
+    // SAFETY: The ACL was built by `SetEntriesInAclW` from one allow entry, so
+    // its sole ACE has the `ACCESS_ALLOWED_ACE` layout.
+    let allowed_ace = unsafe { &*ace.cast::<ACCESS_ALLOWED_ACE>() };
+    if allowed_ace.Header.AceFlags as u32 & INHERITED_ACE != 0 {
+        return Ok(false);
+    }
+    let ace_sid = (&raw const allowed_ace.SidStart).cast_mut().cast();
+
+    // SAFETY: Both SID pointers are valid for this call while `descriptor` and
+    // `current_user` remain alive.
+    Ok(unsafe { EqualSid(ace_sid, current_user.as_ptr()) } != 0)
+}

--- a/crates/container/Cargo.toml
+++ b/crates/container/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "container"
-version = "0.3.75"
+version = "0.3.76"
 edition = "2024"
 
 [dependencies]

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db"
-version = "0.3.75"
+version = "0.3.76"
 edition = "2024"
 
 [dependencies]

--- a/crates/ebpf-redirect/Cargo.lock
+++ b/crates/ebpf-redirect/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "ebpf-redirect"
-version = "0.3.75"
+version = "0.3.76"
 dependencies = [
  "aya-ebpf",
 ]

--- a/crates/ebpf-redirect/Cargo.toml
+++ b/crates/ebpf-redirect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ebpf-redirect"
-version = "0.3.75"
+version = "0.3.76"
 edition = "2021"
 
 [dependencies]

--- a/crates/libvirt/Cargo.toml
+++ b/crates/libvirt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libvirt"
-version = "0.3.75"
+version = "0.3.76"
 edition = "2024"
 
 [dependencies]

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network"
-version = "0.3.75"
+version = "0.3.76"
 edition = "2024"
 
 [dependencies]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sherpad"
-version = "0.3.75"
+version = "0.3.76"
 edition = "2024"
 
 [dependencies]

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared"
-version = "0.3.75"
+version = "0.3.76"
 edition = "2024"
 
 [dependencies]

--- a/crates/shared/src/util/file_system.rs
+++ b/crates/shared/src/util/file_system.rs
@@ -7,7 +7,9 @@ use std::path::Path;
 #[cfg(unix)]
 use std::process::Command;
 
-use anyhow::{Context, Result, bail};
+#[cfg(unix)]
+use anyhow::bail;
+use anyhow::{Context, Result};
 
 use crate::data::{NodeKind, UnikernelBootMode};
 use crate::konst::{UNIKERNEL_DISK_FILENAME, UNIKERNEL_KERNEL_FILENAME, VM_DISK_FILENAME};

--- a/crates/template/Cargo.toml
+++ b/crates/template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "template"
-version = "0.3.75"
+version = "0.3.76"
 edition = "2024"
 
 [dependencies]

--- a/crates/topology/Cargo.toml
+++ b/crates/topology/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topology"
-version = "0.3.75"
+version = "0.3.76"
 edition = "2024"
 
 [dependencies]

--- a/crates/validate/Cargo.toml
+++ b/crates/validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "validate"
-version = "0.3.75"
+version = "0.3.76"
 edition = "2024"
 
 [dependencies]

--- a/test-specs/client/cli-commands.md
+++ b/test-specs/client/cli-commands.md
@@ -21,6 +21,8 @@
 - Missing token directs user to `sherpa login` `[integration]` **P0**
 - Streaming progress messages displayed during lab creation `[integration]` **P1**
 - SSH config and private key written locally on success `[integration]` **P1**
+- SSH private key is restricted to mode 0600 on Unix and a protected current-user-only DACL on Windows `[unit]` **P0**
+- Failed private key permission hardening removes the insecure local key `[unit]` **P0**
 - lab-info.toml written on success `[integration]` **P1**
 - Results displayed in table format `[integration]` **P2**
 - 15-minute extended timeout used for long operations `[unit]` **P1**
@@ -158,10 +160,21 @@
 
 **What to test:**
 - SSH invoked with correct node name and sherpa-ssh-config `[integration]` **P0**
+- Existing private key permissions are repaired before SSH is invoked `[unit]` **P0**
+- SSH is not invoked when private key permissions cannot be secured `[unit]` **P0**
 - Missing SSH config file handled gracefully `[integration]` **P1**
 - Existing `sherpa ssh <node>` command shape remains unchanged `[unit]` **P0**
 
 **Existing coverage:** Node name qualification unit tests in `cmd/ssh.rs`; CLI parse test for `sherpa ssh <node>`
+
+---
+
+## `download` — Download Lab Files
+
+**What to test:**
+- Downloaded SSH private key uses mode 0600 on Unix `[unit]` **P0**
+- Downloaded SSH private key uses a protected current-user-only DACL on Windows `[unit]` **P0**
+- Permission hardening failure removes the downloaded private key and returns an error `[unit]` **P0**
 
 ---
 


### PR DESCRIPTION
## Summary

- centralize SSH private-key writing and permission hardening
- apply Unix mode 0600 and a protected current-user-only Windows DACL using native Win32 APIs
- repair existing key permissions before invoking SSH and remove newly written keys when hardening fails
- add focused Windows client Clippy and ACL tests to PR CI

## Validation

- cargo fmt --check
- cargo clippy --workspace -- -D warnings
- cargo test -p sherpa private_key::tests
- cargo test --workspace
- actionlint .github/workflows/pr.yml
- isolated x86_64-pc-windows-msvc type-check of the native ACL module