### PR TITLE
fix(web): recover from stale session cookies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -988,7 +988,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "container"
-version = "0.3.76"
+version = "0.3.77"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1204,7 +1204,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "db"
-version = "0.3.76"
+version = "0.3.77"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -2664,7 +2664,7 @@ dependencies = [
 
 [[package]]
 name = "libvirt"
-version = "0.3.76"
+version = "0.3.77"
 dependencies = [
  "anyhow",
  "askama",
@@ -2939,7 +2939,7 @@ dependencies = [
 
 [[package]]
 name = "network"
-version = "0.3.76"
+version = "0.3.77"
 dependencies = [
  "anyhow",
  "aya",
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "0.3.76"
+version = "0.3.77"
 dependencies = [
  "anyhow",
  "argon2",
@@ -4883,7 +4883,7 @@ dependencies = [
 
 [[package]]
 name = "sherpa"
-version = "0.3.76"
+version = "0.3.77"
 dependencies = [
  "anyhow",
  "askama",
@@ -4919,7 +4919,7 @@ dependencies = [
 
 [[package]]
 name = "sherpad"
-version = "0.3.76"
+version = "0.3.77"
 dependencies = [
  "anyhow",
  "askama",
@@ -5504,7 +5504,7 @@ dependencies = [
 
 [[package]]
 name = "template"
-version = "0.3.76"
+version = "0.3.77"
 dependencies = [
  "anyhow",
  "askama",
@@ -5881,7 +5881,7 @@ dependencies = [
 
 [[package]]
 name = "topology"
-version = "0.3.76"
+version = "0.3.77"
 dependencies = [
  "anyhow",
  "serde",
@@ -6195,7 +6195,7 @@ dependencies = [
 
 [[package]]
 name = "validate"
-version = "0.3.76"
+version = "0.3.77"
 dependencies = [
  "anyhow",
  "shared",

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sherpa"
-version = "0.3.76"
+version = "0.3.77"
 edition = "2024"
 
 [dependencies]

--- a/crates/container/Cargo.toml
+++ b/crates/container/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "container"
-version = "0.3.76"
+version = "0.3.77"
 edition = "2024"
 
 [dependencies]

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "db"
-version = "0.3.76"
+version = "0.3.77"
 edition = "2024"
 
 [dependencies]

--- a/crates/ebpf-redirect/Cargo.lock
+++ b/crates/ebpf-redirect/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "ebpf-redirect"
-version = "0.3.76"
+version = "0.3.77"
 dependencies = [
  "aya-ebpf",
 ]

--- a/crates/ebpf-redirect/Cargo.toml
+++ b/crates/ebpf-redirect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ebpf-redirect"
-version = "0.3.76"
+version = "0.3.77"
 edition = "2021"
 
 [dependencies]

--- a/crates/libvirt/Cargo.toml
+++ b/crates/libvirt/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "libvirt"
-version = "0.3.76"
+version = "0.3.77"
 edition = "2024"
 
 [dependencies]

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "network"
-version = "0.3.76"
+version = "0.3.77"
 edition = "2024"
 
 [dependencies]

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sherpad"
-version = "0.3.76"
+version = "0.3.77"
 edition = "2024"
 
 [dependencies]

--- a/crates/server/src/api/extractors.rs
+++ b/crates/server/src/api/extractors.rs
@@ -2,11 +2,235 @@ use axum::extract::FromRequestParts;
 use axum::http::header;
 use axum::http::request::Parts;
 use axum::response::{IntoResponse, Redirect, Response};
+use jsonwebtoken::errors::{Error as JwtError, ErrorKind};
+use shared::auth::jwt::Claims;
 
 use crate::auth::{context::AuthContext, cookies, jwt};
 use crate::daemon::state::AppState;
 
 use super::errors::ApiError;
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum SessionFailureReason {
+    Expired,
+    InvalidSignature,
+    Malformed,
+    InvalidClaims,
+}
+
+impl SessionFailureReason {
+    fn as_str(self) -> &'static str {
+        match self {
+            Self::Expired => "expired",
+            Self::InvalidSignature => "invalid_signature",
+            Self::Malformed => "malformed",
+            Self::InvalidClaims => "invalid_claims",
+        }
+    }
+
+    fn is_suspicious(self) -> bool {
+        matches!(self, Self::InvalidSignature | Self::Malformed)
+    }
+}
+
+#[derive(Debug)]
+pub(super) struct RejectedSessionCandidate {
+    index: usize,
+    reason: SessionFailureReason,
+    signed_claims: Option<Claims>,
+}
+
+#[derive(Debug)]
+pub(super) struct ValidatedCookieSession {
+    pub(super) claims: Claims,
+    pub(super) candidate_count: usize,
+    pub(super) selected_index: usize,
+    rejected_candidates: Vec<RejectedSessionCandidate>,
+}
+
+#[derive(Debug)]
+pub(super) enum CookieSessionError {
+    Missing,
+    Invalid {
+        candidate_count: usize,
+        rejected_candidates: Vec<RejectedSessionCandidate>,
+    },
+}
+
+fn classify_session_failure(error: &anyhow::Error) -> SessionFailureReason {
+    let Some(jwt_error) = error.downcast_ref::<JwtError>() else {
+        return SessionFailureReason::InvalidClaims;
+    };
+
+    match jwt_error.kind() {
+        ErrorKind::ExpiredSignature => SessionFailureReason::Expired,
+        ErrorKind::InvalidSignature => SessionFailureReason::InvalidSignature,
+        ErrorKind::InvalidToken
+        | ErrorKind::InvalidAlgorithm
+        | ErrorKind::InvalidAlgorithmName
+        | ErrorKind::MissingAlgorithm
+        | ErrorKind::Base64(_)
+        | ErrorKind::Json(_)
+        | ErrorKind::Utf8(_) => SessionFailureReason::Malformed,
+        _ => SessionFailureReason::InvalidClaims,
+    }
+}
+
+#[tracing::instrument(level = "debug", skip(cookie_header, jwt_secret))]
+pub(super) fn validate_cookie_session(
+    cookie_header: Option<&str>,
+    jwt_secret: &[u8],
+) -> Result<ValidatedCookieSession, CookieSessionError> {
+    let cookie_header = cookie_header.ok_or(CookieSessionError::Missing)?;
+    let tokens = cookies::extract_tokens_from_cookie(cookie_header);
+    if tokens.is_empty() {
+        return Err(CookieSessionError::Missing);
+    }
+
+    let candidate_count = tokens.len();
+    let mut rejected_candidates = Vec::new();
+
+    for (index, token) in tokens.into_iter().enumerate() {
+        match jwt::validate_token(jwt_secret, token) {
+            Ok(claims) => {
+                return Ok(ValidatedCookieSession {
+                    claims,
+                    candidate_count,
+                    selected_index: index,
+                    rejected_candidates,
+                });
+            }
+            Err(error) => {
+                let reason = classify_session_failure(&error);
+                let signed_claims = (reason == SessionFailureReason::Expired)
+                    .then(|| jwt::validate_expired_token_for_diagnostics(jwt_secret, token).ok())
+                    .flatten();
+                rejected_candidates.push(RejectedSessionCandidate {
+                    index,
+                    reason,
+                    signed_claims,
+                });
+            }
+        }
+    }
+
+    Err(CookieSessionError::Invalid {
+        candidate_count,
+        rejected_candidates,
+    })
+}
+
+#[tracing::instrument(level = "debug", skip(session), fields(path))]
+pub(super) fn trace_validated_session(path: &str, session: &ValidatedCookieSession) {
+    if session.rejected_candidates.is_empty() {
+        tracing::debug!(
+            event = "auth.session_validated",
+            path,
+            username = %session.claims.sub,
+            is_admin = session.claims.is_admin,
+            issued_at = session.claims.iat,
+            expires_at = session.claims.exp,
+            cookie_candidate_count = session.candidate_count,
+            selected_candidate_index = session.selected_index,
+            "Session cookie validated"
+        );
+        return;
+    }
+
+    let rejected_reasons: Vec<&str> = session
+        .rejected_candidates
+        .iter()
+        .map(|candidate| candidate.reason.as_str())
+        .collect();
+    let rejected_indices: Vec<usize> = session
+        .rejected_candidates
+        .iter()
+        .map(|candidate| candidate.index)
+        .collect();
+    tracing::warn!(
+        event = "auth.session_duplicate_recovered",
+        path,
+        username = %session.claims.sub,
+        is_admin = session.claims.is_admin,
+        issued_at = session.claims.iat,
+        expires_at = session.claims.exp,
+        cookie_candidate_count = session.candidate_count,
+        selected_candidate_index = session.selected_index,
+        rejected_candidate_indices = ?rejected_indices,
+        rejected_reasons = ?rejected_reasons,
+        "Recovered session using a valid duplicate cookie"
+    );
+}
+
+#[tracing::instrument(level = "debug", skip(error), fields(path, action))]
+pub(super) fn trace_rejected_session(path: &str, error: &CookieSessionError, action: &'static str) {
+    match error {
+        CookieSessionError::Missing => {
+            tracing::debug!(
+                event = "auth.session_missing",
+                path,
+                action,
+                "No session cookie was supplied"
+            );
+        }
+        CookieSessionError::Invalid {
+            candidate_count,
+            rejected_candidates,
+        } => {
+            let reasons: Vec<&str> = rejected_candidates
+                .iter()
+                .map(|candidate| candidate.reason.as_str())
+                .collect();
+            let signed_claims = rejected_candidates
+                .iter()
+                .find_map(|candidate| candidate.signed_claims.as_ref());
+            let suspicious = rejected_candidates
+                .iter()
+                .any(|candidate| candidate.reason.is_suspicious());
+
+            if suspicious {
+                tracing::warn!(
+                    event = "auth.session_rejected",
+                    path,
+                    action,
+                    cookie_candidate_count = candidate_count,
+                    validation_reasons = ?reasons,
+                    "Rejected invalid session cookies"
+                );
+            } else if let Some(claims) = signed_claims {
+                tracing::info!(
+                    event = "auth.session_rejected",
+                    path,
+                    action,
+                    cookie_candidate_count = candidate_count,
+                    validation_reasons = ?reasons,
+                    username = %claims.sub,
+                    is_admin = claims.is_admin,
+                    issued_at = claims.iat,
+                    expires_at = claims.exp,
+                    "Rejected expired session cookie"
+                );
+            } else {
+                tracing::info!(
+                    event = "auth.session_rejected",
+                    path,
+                    action,
+                    cookie_candidate_count = candidate_count,
+                    validation_reasons = ?reasons,
+                    "Rejected invalid session cookies"
+                );
+            }
+
+            tracing::info!(
+                event = "auth.session_cleared",
+                path,
+                action,
+                cookie_candidate_count = candidate_count,
+                "Clearing invalid session cookie"
+            );
+        }
+    }
+}
 
 // Extractor logic helper: extract and validate token from Authorization header or Cookie
 fn extract_and_validate_token(
@@ -22,11 +246,11 @@ fn extract_and_validate_token(
     }
 
     // Fall back to cookie
-    if let Some(cookie_header) = headers.get(header::COOKIE).and_then(|h| h.to_str().ok())
-        && let Some(token) = cookies::extract_token_from_cookie(cookie_header)
-        && let Ok(claims) = jwt::validate_token(jwt_secret, &token)
-    {
-        return Ok((claims.sub, claims.is_admin));
+    if let Ok(session) = validate_cookie_session(
+        headers.get(header::COOKIE).and_then(|h| h.to_str().ok()),
+        jwt_secret,
+    ) {
+        return Ok((session.claims.sub, session.claims.is_admin));
     }
 
     Err("Missing or invalid authentication")
@@ -68,7 +292,8 @@ impl FromRequestParts<AppState> for AuthenticatedUser {
 ///
 /// Use this for HTML routes that should redirect to login on authentication failure.
 /// This extractor ONLY checks cookies (not Authorization headers).
-/// On authentication failure, returns a redirect to `/login?error=session_required`.
+/// Missing sessions redirect with `session_required`; invalid sessions are cleared and redirect
+/// with `session_expired`.
 #[derive(Debug, Clone)]
 pub struct AuthenticatedUserFromCookie {
     pub username: String,
@@ -83,12 +308,30 @@ impl AuthenticatedUserFromCookie {
     }
 }
 
-/// Custom rejection type that redirects to login
-pub struct AuthRedirect;
+/// Custom rejection type that redirects to login.
+#[derive(Debug, Clone, Copy)]
+pub enum AuthRedirect {
+    SessionRequired,
+    InvalidSession,
+}
 
 impl IntoResponse for AuthRedirect {
     fn into_response(self) -> Response {
-        Redirect::to("/login?error=session_required").into_response()
+        match self {
+            Self::SessionRequired => Redirect::to("/login?error=session_required").into_response(),
+            Self::InvalidSession => (
+                [(header::SET_COOKIE, cookies::create_clear_cookie())],
+                Redirect::to("/login?error=session_expired"),
+            )
+                .into_response(),
+        }
+    }
+}
+
+fn redirect_for_session_error(error: &CookieSessionError) -> AuthRedirect {
+    match error {
+        CookieSessionError::Missing => AuthRedirect::SessionRequired,
+        CookieSessionError::Invalid { .. } => AuthRedirect::InvalidSession,
     }
 }
 
@@ -99,25 +342,23 @@ impl FromRequestParts<AppState> for AuthenticatedUserFromCookie {
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        // Extract cookie header
-        let cookie_header = parts
-            .headers
-            .get(header::COOKIE)
-            .and_then(|h| h.to_str().ok())
-            .ok_or(AuthRedirect)?;
-
-        // Extract token from cookies
-        let token = cookies::extract_token_from_cookie(cookie_header).ok_or(AuthRedirect)?;
-
-        // Validate token
-        let claims = jwt::validate_token(&state.jwt_secret, &token).map_err(|e| {
-            tracing::debug!("Cookie token validation failed: {}", e);
-            AuthRedirect
+        let path = parts.uri.path();
+        let session = validate_cookie_session(
+            parts
+                .headers
+                .get(header::COOKIE)
+                .and_then(|value| value.to_str().ok()),
+            &state.jwt_secret,
+        )
+        .map_err(|error| {
+            trace_rejected_session(path, &error, "redirect_to_login");
+            redirect_for_session_error(&error)
         })?;
+        trace_validated_session(path, &session);
 
         Ok(AuthenticatedUserFromCookie {
-            username: claims.sub,
-            is_admin: claims.is_admin,
+            username: session.claims.sub,
+            is_admin: session.claims.is_admin,
         })
     }
 }
@@ -165,22 +406,20 @@ impl FromRequestParts<AppState> for AdminUser {
         parts: &mut Parts,
         state: &AppState,
     ) -> Result<Self, Self::Rejection> {
-        // Extract cookie header
-        let cookie_header = parts
-            .headers
-            .get(header::COOKIE)
-            .and_then(|h| h.to_str().ok())
-            .ok_or_else(|| AuthRedirect.into_response())?;
-
-        // Extract token from cookies
-        let token = cookies::extract_token_from_cookie(cookie_header)
-            .ok_or_else(|| AuthRedirect.into_response())?;
-
-        // Validate token
-        let claims = jwt::validate_token(&state.jwt_secret, &token).map_err(|e| {
-            tracing::debug!("Cookie token validation failed: {}", e);
-            AuthRedirect.into_response()
+        let path = parts.uri.path();
+        let session = validate_cookie_session(
+            parts
+                .headers
+                .get(header::COOKIE)
+                .and_then(|value| value.to_str().ok()),
+            &state.jwt_secret,
+        )
+        .map_err(|error| {
+            trace_rejected_session(path, &error, "redirect_to_login");
+            redirect_for_session_error(&error).into_response()
         })?;
+        trace_validated_session(path, &session);
+        let claims = session.claims;
 
         // Check if user is admin
         if !claims.is_admin {
@@ -206,6 +445,25 @@ mod tests {
     use axum::http::HeaderMap;
     use jsonwebtoken::{EncodingKey, Header, encode};
     use shared::auth::jwt::Claims;
+    use std::io::Write;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Clone)]
+    struct CapturedWriter(Arc<Mutex<Vec<u8>>>);
+
+    impl Write for CapturedWriter {
+        fn write(&mut self, buf: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("trace buffer lock poisoned")
+                .extend(buf);
+            Ok(buf.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
 
     const TEST_SECRET: &[u8] = b"test_secret_32_bytes_long_enough";
 
@@ -360,6 +618,96 @@ mod tests {
 
         let result = extract_and_validate_token(&headers, TEST_SECRET);
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_expired_cookie_before_valid_replacement_recovers() {
+        let expired_token = make_expired_token();
+        let valid_token = make_token("replacement_user", false);
+        let cookie_header = format!("sherpa_auth={}; sherpa_auth={}", expired_token, valid_token);
+
+        let session = validate_cookie_session(Some(&cookie_header), TEST_SECRET)
+            .expect("valid replacement cookie should be accepted");
+
+        assert_eq!(session.claims.sub, "replacement_user");
+        assert_eq!(session.candidate_count, 2);
+        assert_eq!(session.selected_index, 1);
+        assert_eq!(session.rejected_candidates.len(), 1);
+        assert_eq!(
+            session.rejected_candidates[0].reason,
+            SessionFailureReason::Expired
+        );
+    }
+
+    #[test]
+    fn test_valid_cookie_before_expired_duplicate_succeeds() {
+        let valid_token = make_token("first_user", true);
+        let expired_token = make_expired_token();
+        let cookie_header = format!("sherpa_auth={}; sherpa_auth={}", valid_token, expired_token);
+
+        let session = validate_cookie_session(Some(&cookie_header), TEST_SECRET)
+            .expect("first valid cookie should be accepted");
+
+        assert_eq!(session.claims.sub, "first_user");
+        assert_eq!(session.candidate_count, 2);
+        assert_eq!(session.selected_index, 0);
+        assert!(session.rejected_candidates.is_empty());
+    }
+
+    #[test]
+    fn test_invalid_session_redirect_clears_cookie() {
+        let response = AuthRedirect::InvalidSession.into_response();
+
+        assert_eq!(response.status(), axum::http::StatusCode::SEE_OTHER);
+        assert_eq!(
+            response.headers().get(header::LOCATION).unwrap(),
+            "/login?error=session_expired"
+        );
+        let clear_cookie = response
+            .headers()
+            .get(header::SET_COOKIE)
+            .expect("invalid session redirect should clear the cookie")
+            .to_str()
+            .expect("clear cookie should be a valid header");
+        assert!(clear_cookie.contains("Max-Age=0"));
+        assert!(clear_cookie.contains("Expires=Thu, 01 Jan 1970 00:00:00 GMT"));
+    }
+
+    #[test]
+    fn test_missing_session_redirect_does_not_set_cookie() {
+        let response = AuthRedirect::SessionRequired.into_response();
+
+        assert_eq!(response.status(), axum::http::StatusCode::SEE_OTHER);
+        assert_eq!(
+            response.headers().get(header::LOCATION).unwrap(),
+            "/login?error=session_required"
+        );
+        assert!(!response.headers().contains_key(header::SET_COOKIE));
+    }
+
+    #[test]
+    fn test_rejected_session_trace_does_not_include_raw_cookie() {
+        const RAW_COOKIE: &str = "sherpa_auth=SUPER_SECRET_RAW_TOKEN";
+        let output = Arc::new(Mutex::new(Vec::new()));
+        let writer = CapturedWriter(Arc::clone(&output));
+        let subscriber = tracing_subscriber::fmt()
+            .with_ansi(false)
+            .without_time()
+            .with_writer(move || writer.clone())
+            .finish();
+        let error = validate_cookie_session(Some(RAW_COOKIE), TEST_SECRET)
+            .expect_err("malformed session should be rejected");
+
+        tracing::subscriber::with_default(subscriber, || {
+            trace_rejected_session("/", &error, "redirect_to_login");
+        });
+
+        let output = output.lock().expect("trace buffer lock poisoned");
+        let output = String::from_utf8_lossy(&output);
+        assert!(output.contains("auth.session_rejected"));
+        assert!(output.contains("malformed"));
+        assert!(!output.contains("SUPER_SECRET_RAW_TOKEN"));
+        assert!(!output.contains(RAW_COOKIE));
     }
 
     // ============================================================================

--- a/crates/server/src/api/handlers.rs
+++ b/crates/server/src/api/handlers.rs
@@ -1,6 +1,6 @@
 use askama::Template;
 use axum::extract::{Multipart, Path, Query, State};
-use axum::http::{StatusCode, header};
+use axum::http::{HeaderMap, StatusCode, header};
 use axum::response::{Html, IntoResponse, Response, sse};
 use axum::{Form, Json};
 use jiff::Timestamp;
@@ -32,7 +32,10 @@ use crate::templates::{
 };
 
 use super::errors::ApiError;
-use super::extractors::{AdminUser, AuthenticatedUser, AuthenticatedUserFromCookie};
+use super::extractors::{
+    AdminUser, AuthenticatedUser, AuthenticatedUserFromCookie, CookieSessionError,
+    trace_rejected_session, trace_validated_session, validate_cookie_session,
+};
 
 use shared::api_spec;
 use shared::auth::{password, ssh};
@@ -96,7 +99,16 @@ pub async fn login(
     let now = Timestamp::now().as_second();
     let expires_at = now + JWT_TOKEN_EXPIRY_SECONDS;
 
-    tracing::info!("User '{}' logged in successfully", user.username);
+    tracing::info!(
+        event = "auth.login_succeeded",
+        channel = "api",
+        username = %user.username,
+        is_admin = user.is_admin,
+        issued_at = now,
+        expires_at,
+        session_duration_seconds = JWT_TOKEN_EXPIRY_SECONDS,
+        "User logged in successfully"
+    );
 
     Ok(Json(LoginResponse {
         token,
@@ -138,9 +150,11 @@ pub struct SignupForm {
 /// - `error`: Optional error code (session_required, session_expired, logout_success)
 /// - `message`: Optional informational message
 pub async fn login_page_handler(
+    State(state): State<AppState>,
+    headers: HeaderMap,
     Query(params): Query<HashMap<String, String>>,
-) -> impl IntoResponse {
-    let error = params
+) -> Response {
+    let mut error = params
         .get("error")
         .map(|s| s.to_string())
         .unwrap_or_default();
@@ -149,7 +163,30 @@ pub async fn login_page_handler(
         .map(|s| s.to_string())
         .unwrap_or_default();
 
-    LoginPageTemplate { error, message }
+    let cookie_header = headers
+        .get(header::COOKIE)
+        .and_then(|value| value.to_str().ok());
+    match validate_cookie_session(cookie_header, &state.jwt_secret) {
+        Ok(session) => {
+            trace_validated_session("/login", &session);
+            let redirect_path = if session.claims.is_admin {
+                "/admin/users"
+            } else {
+                "/"
+            };
+            axum::response::Redirect::to(redirect_path).into_response()
+        }
+        Err(CookieSessionError::Missing) => LoginPageTemplate { error, message }.into_response(),
+        Err(session_error) => {
+            trace_rejected_session("/login", &session_error, "clear_and_render_login");
+            error = "session_expired".to_string();
+            (
+                [(header::SET_COOKIE, cookies::create_clear_cookie())],
+                LoginPageTemplate { error, message },
+            )
+                .into_response()
+        }
+    }
 }
 
 /// Process login form submission
@@ -229,10 +266,18 @@ pub async fn login_form_handler(
     // Create auth cookie
     let cookie_value = cookies::create_auth_cookie(&token, form.remember_me);
 
+    let issued_at = Timestamp::now().as_second();
+    let expires_at = issued_at + expiry_seconds;
     tracing::info!(
-        "User '{}' logged in successfully (remember_me: {})",
-        user.username,
-        form.remember_me
+        event = "auth.login_succeeded",
+        channel = "web",
+        username = %user.username,
+        is_admin = user.is_admin,
+        remember_me = form.remember_me,
+        issued_at,
+        expires_at,
+        session_duration_seconds = expiry_seconds,
+        "User logged in successfully"
     );
 
     // Redirect admin users to /admin, regular users to /

--- a/crates/server/src/auth/cookies.rs
+++ b/crates/server/src/auth/cookies.rs
@@ -44,9 +44,21 @@ pub fn create_auth_cookie(token: &str, remember_me: bool) -> String {
 /// A Set-Cookie header value string that clears the auth cookie
 pub fn create_clear_cookie() -> String {
     format!(
-        "{}=; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=0",
+        "{}=; Path=/; HttpOnly; Secure; SameSite=Strict; Max-Age=0; Expires=Thu, 01 Jan 1970 00:00:00 GMT",
         AUTH_COOKIE_NAME
     )
+}
+
+/// Extract every authentication token from a Cookie header.
+#[tracing::instrument(level = "debug", skip(cookie_header))]
+pub(crate) fn extract_tokens_from_cookie(cookie_header: &str) -> Vec<&str> {
+    cookie_header
+        .split(';')
+        .filter_map(|cookie| {
+            let (name, value) = cookie.trim().split_once('=')?;
+            (name == AUTH_COOKIE_NAME).then_some(value)
+        })
+        .collect()
 }
 
 /// Extracts the JWT token from a Cookie header value.
@@ -59,16 +71,9 @@ pub fn create_clear_cookie() -> String {
 /// # Returns
 /// The token string if found, None otherwise
 pub fn extract_token_from_cookie(cookie_header: &str) -> Option<String> {
-    // Parse cookies in format "name1=value1; name2=value2"
-    for cookie in cookie_header.split(';') {
-        let cookie = cookie.trim();
-        if let Some((name, value)) = cookie.split_once('=')
-            && name == AUTH_COOKIE_NAME
-        {
-            return Some(value.to_string());
-        }
-    }
-    None
+    extract_tokens_from_cookie(cookie_header)
+        .first()
+        .map(|token| (*token).to_string())
 }
 
 #[cfg(test)]
@@ -102,8 +107,18 @@ mod tests {
 
         assert!(cookie.contains("sherpa_auth="));
         assert!(cookie.contains("Max-Age=0"));
+        assert!(cookie.contains("Expires=Thu, 01 Jan 1970 00:00:00 GMT"));
         assert!(cookie.contains("HttpOnly"));
         assert!(cookie.contains("SameSite=Strict"));
+    }
+
+    #[test]
+    fn test_extract_all_duplicate_auth_tokens() {
+        let cookie_header = "sherpa_auth=expired_token; other=value; sherpa_auth=replacement_token";
+
+        let tokens = extract_tokens_from_cookie(cookie_header);
+
+        assert_eq!(tokens, vec!["expired_token", "replacement_token"]);
     }
 
     #[test]

--- a/crates/server/src/auth/jwt.rs
+++ b/crates/server/src/auth/jwt.rs
@@ -160,6 +160,20 @@ pub fn validate_token(secret: &[u8], token: &str) -> Result<Claims> {
     Ok(token_data.claims)
 }
 
+/// Validate a token's signature and claims while allowing an expired `exp` value.
+///
+/// This is used only to recover safe diagnostic metadata from an expired token.
+#[tracing::instrument(level = "debug", skip(secret, token))]
+pub(crate) fn validate_expired_token_for_diagnostics(secret: &[u8], token: &str) -> Result<Claims> {
+    let mut validation = Validation::default();
+    validation.validate_exp = false;
+
+    let token_data = decode::<Claims>(token, &DecodingKey::from_secret(secret), &validation)
+        .context("Failed to validate expired JWT token for diagnostics")?;
+
+    Ok(token_data.claims)
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/server/tests/auth_tests.rs
+++ b/crates/server/tests/auth_tests.rs
@@ -3,6 +3,7 @@ mod helpers;
 mod http_client;
 
 use anyhow::Result;
+use reqwest::header;
 use serde_json::json;
 
 use helpers::test_server::TestServer;
@@ -398,6 +399,83 @@ async fn test_http_bearer_auth_delete_user() -> Result<()> {
         "DELETE /api/v1/admin/users/httpdel should return 200, got: {}",
         response.status()
     );
+
+    Ok(())
+}
+
+#[tokio::test]
+#[ignore]
+async fn test_stale_cookie_login_recovery_and_duplicate_replacement() -> Result<()> {
+    let server = TestServer::start().await?;
+    let client = TestHttpClient::new(server.addr);
+
+    let stale_response = client
+        .get_with_cookie("/", "sherpa_auth=stale-session")
+        .await?;
+    assert_eq!(stale_response.status().as_u16(), 303);
+    assert_eq!(
+        stale_response
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|value| value.to_str().ok()),
+        Some("/login?error=session_expired")
+    );
+    let clear_cookie = stale_response
+        .headers()
+        .get(header::SET_COOKIE)
+        .expect("stale session response should clear the cookie")
+        .to_str()?;
+    assert!(clear_cookie.contains("Max-Age=0"));
+
+    let stale_login_page = client
+        .get_with_cookie("/login", "sherpa_auth=stale-session")
+        .await?;
+    assert_eq!(stale_login_page.status().as_u16(), 200);
+    let login_page_clear_cookie = stale_login_page
+        .headers()
+        .get(header::SET_COOKIE)
+        .expect("login page should clear an invalid session")
+        .to_str()?;
+    assert!(login_page_clear_cookie.contains("Max-Age=0"));
+
+    let login_response = client
+        .post_form(
+            "/login",
+            &[
+                ("username", "admin"),
+                ("password", helpers::test_server::TEST_ADMIN_PASSWORD),
+            ],
+        )
+        .await?;
+    assert_eq!(login_response.status().as_u16(), 200);
+    let replacement_cookie = login_response
+        .headers()
+        .get_all(header::SET_COOKIE)
+        .iter()
+        .filter_map(|value| value.to_str().ok())
+        .find_map(|value| {
+            value
+                .split(';')
+                .next()
+                .filter(|pair| pair.starts_with("sherpa_auth="))
+        })
+        .expect("successful login should return an auth cookie");
+
+    let authenticated_login_page = client.get_with_cookie("/login", replacement_cookie).await?;
+    assert_eq!(authenticated_login_page.status().as_u16(), 303);
+    assert_eq!(
+        authenticated_login_page
+            .headers()
+            .get(header::LOCATION)
+            .and_then(|value| value.to_str().ok()),
+        Some("/admin/users")
+    );
+
+    let duplicate_cookie = format!("sherpa_auth=stale-session; {replacement_cookie}");
+    let protected_response = client
+        .get_with_cookie("/admin/users", &duplicate_cookie)
+        .await?;
+    assert_eq!(protected_response.status().as_u16(), 200);
 
     Ok(())
 }

--- a/crates/server/tests/helpers/http_client.rs
+++ b/crates/server/tests/helpers/http_client.rs
@@ -1,4 +1,5 @@
 use anyhow::{Context, Result};
+use reqwest::header;
 use reqwest::{Client, Response, StatusCode};
 use std::net::SocketAddr;
 use std::sync::Arc;
@@ -40,6 +41,18 @@ impl TestHttpClient {
             req = req.bearer_auth(token);
         }
         req.send().await.context("HTTP GET failed")
+    }
+
+    /// GET request with an explicit Cookie header.
+    #[tracing::instrument(level = "debug", skip(self, cookie_header), fields(path))]
+    pub async fn get_with_cookie(&self, path: &str, cookie_header: &str) -> Result<Response> {
+        let url = format!("{}{}", self.base_url, path);
+        self.client
+            .get(&url)
+            .header(header::COOKIE, cookie_header)
+            .send()
+            .await
+            .context("HTTP GET with cookie failed")
     }
 
     /// POST request with form data

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "shared"
-version = "0.3.76"
+version = "0.3.77"
 edition = "2024"
 
 [dependencies]

--- a/crates/template/Cargo.toml
+++ b/crates/template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "template"
-version = "0.3.76"
+version = "0.3.77"
 edition = "2024"
 
 [dependencies]

--- a/crates/topology/Cargo.toml
+++ b/crates/topology/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "topology"
-version = "0.3.76"
+version = "0.3.77"
 edition = "2024"
 
 [dependencies]

--- a/crates/validate/Cargo.toml
+++ b/crates/validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "validate"
-version = "0.3.76"
+version = "0.3.77"
 edition = "2024"
 
 [dependencies]

--- a/test-specs/server/auth.md
+++ b/test-specs/server/auth.md
@@ -25,7 +25,11 @@
 - Cookie used for subsequent HTTP requests `[integration]` **P0**
 - Logout clears cookie `[integration]` **P0**
 - Expired cookie rejected `[integration]` **P1**
+- Expired or invalid cookie is cleared before redirecting to login `[integration]` **P0**
+- Duplicate auth cookies accept a valid replacement regardless of ordering `[unit]` **P0**
+- Stale cookie followed by successful login can access a protected page `[integration]` **P0**
 - Cookie secure flag behavior (HTTPS vs HTTP) `[integration]` **P2**
+- Session tracing records safe validation and recovery metadata without raw tokens or passwords `[unit]` **P0**
 
 ---
 


### PR DESCRIPTION
## Summary

- clear expired or invalid session cookies before returning users to login
- accept a valid replacement when duplicate `sherpa_auth` cookies are present
- add structured session validation and recovery tracing without logging raw cookies, JWTs, or passwords
- add unit and HTTP regression coverage for stale-session recovery
- bump all workspace crates to `0.3.77` in a separate commit

## Validation

- `cargo fmt`
- `cargo clippy --workspace -- -D warnings`
- targeted stale-session HTTP integration test
- `cargo test --workspace`

