### PR TITLE
chore: consolidate workspace dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -387,39 +387,11 @@ dependencies = [
 
 [[package]]
 name = "axum"
-version = "0.7.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edca88bc138befd0323b20752846e6587272d3b03b0343c8ea28a6f819e6e71f"
-dependencies = [
- "async-trait",
- "axum-core 0.4.5",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "itoa",
- "matchit 0.7.3",
- "memchr",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rustversion",
- "serde",
- "sync_wrapper",
- "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum"
 version = "0.8.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
- "axum-core 0.5.6",
+ "axum-core",
  "base64",
  "bytes",
  "form_urlencoded",
@@ -430,7 +402,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "itoa",
- "matchit 0.8.4",
+ "matchit",
  "memchr",
  "mime",
  "multer",
@@ -443,29 +415,8 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tower",
- "tower-layer",
- "tower-service",
- "tracing",
-]
-
-[[package]]
-name = "axum-core"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "09f2bd6146b97ae3359fa0cc6d6b376d9539582c7b4220f041a33ec24c226199"
-dependencies = [
- "async-trait",
- "bytes",
- "futures-util",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "pin-project-lite",
- "rustversion",
- "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -488,30 +439,6 @@ dependencies = [
  "tower-layer",
  "tower-service",
  "tracing",
-]
-
-[[package]]
-name = "axum-extra"
-version = "0.9.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c794b30c904f0a1c2fb7740f7df7f7972dfaa14ef6f57cb6178dc63e5dca2f04"
-dependencies = [
- "axum 0.7.9",
- "axum-core 0.4.5",
- "bytes",
- "fastrand",
- "futures-util",
- "headers",
- "http",
- "http-body",
- "http-body-util",
- "mime",
- "multer",
- "pin-project-lite",
- "serde",
- "tower",
- "tower-layer",
- "tower-service",
 ]
 
 [[package]]
@@ -988,7 +915,7 @@ checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
 
 [[package]]
 name = "container"
-version = "0.3.77"
+version = "0.3.78"
 dependencies = [
  "anyhow",
  "async-compression",
@@ -1204,7 +1131,7 @@ checksum = "d7a1e2f27636f116493b8b860f5546edb47c8d8f8ea73e1d2a20be88e28d1fea"
 
 [[package]]
 name = "db"
-version = "0.3.77"
+version = "0.3.78"
 dependencies = [
  "anyhow",
  "ipnet",
@@ -2580,21 +2507,6 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "9.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a87cc7a48537badeae96744432de36f4be2b4a34a05a5ef32e9dd8a1c169dde"
-dependencies = [
- "base64",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
-name = "jsonwebtoken"
 version = "10.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0529410abe238729a60b108898784df8984c87f6054c9c4fcacc47e4803c1ce1"
@@ -2664,7 +2576,7 @@ dependencies = [
 
 [[package]]
 name = "libvirt"
-version = "0.3.77"
+version = "0.3.78"
 dependencies = [
  "anyhow",
  "askama",
@@ -2754,12 +2666,6 @@ checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
 dependencies = [
  "regex-automata",
 ]
-
-[[package]]
-name = "matchit"
-version = "0.7.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0e7465ac9959cc2b1404e8e2367b43684a6d13790fe23056cc8c6c5a6b7bcb94"
 
 [[package]]
 name = "matchit"
@@ -2939,7 +2845,7 @@ dependencies = [
 
 [[package]]
 name = "network"
-version = "0.3.77"
+version = "0.3.78"
 dependencies = [
  "anyhow",
  "aya",
@@ -2963,18 +2869,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "77a5d83df9f36fe23f0c3648c6bbb8b0298bb5f1939c8f2704431371f4b84d43"
 dependencies = [
  "smallvec",
-]
-
-[[package]]
-name = "nix"
-version = "0.29.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
-dependencies = [
- "bitflags",
- "cfg-if",
- "cfg_aliases",
- "libc",
 ]
 
 [[package]]
@@ -4315,7 +4209,7 @@ dependencies = [
  "netlink-packet-route",
  "netlink-proto",
  "netlink-sys",
- "nix 0.30.1",
+ "nix",
  "thiserror 1.0.69",
  "tokio",
 ]
@@ -4831,7 +4725,7 @@ dependencies = [
 
 [[package]]
 name = "shared"
-version = "0.3.77"
+version = "0.3.78"
 dependencies = [
  "anyhow",
  "argon2",
@@ -4883,7 +4777,7 @@ dependencies = [
 
 [[package]]
 name = "sherpa"
-version = "0.3.77"
+version = "0.3.78"
 dependencies = [
  "anyhow",
  "askama",
@@ -4905,7 +4799,7 @@ dependencies = [
  "tempfile",
  "template",
  "tokio",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite",
  "toml",
  "toml_edit 0.22.27",
  "topology",
@@ -4919,14 +4813,13 @@ dependencies = [
 
 [[package]]
 name = "sherpad"
-version = "0.3.77"
+version = "0.3.78"
 dependencies = [
  "anyhow",
  "askama",
  "async-compression",
  "async-stream",
- "axum 0.8.8",
- "axum-extra",
+ "axum",
  "axum-server",
  "bollard",
  "clap",
@@ -4936,10 +4829,10 @@ dependencies = [
  "futures",
  "futures-util",
  "jiff",
- "jsonwebtoken 9.3.1",
+ "jsonwebtoken",
  "libvirt",
  "network",
- "nix 0.29.0",
+ "nix",
  "opentelemetry",
  "opentelemetry-otlp",
  "opentelemetry_sdk",
@@ -4962,7 +4855,7 @@ dependencies = [
  "time",
  "tokio",
  "tokio-test",
- "tokio-tungstenite 0.24.0",
+ "tokio-tungstenite",
  "tokio-util",
  "toml",
  "toml_edit 0.22.27",
@@ -5244,7 +5137,7 @@ dependencies = [
  "surrealdb-core",
  "surrealdb-types",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "tokio-tungstenite-wasm",
  "tokio-util",
  "tracing",
@@ -5291,7 +5184,7 @@ dependencies = [
  "http",
  "humantime",
  "ipnet",
- "jsonwebtoken 10.3.0",
+ "jsonwebtoken",
  "lexicmp",
  "md-5",
  "mime",
@@ -5504,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "template"
-version = "0.3.77"
+version = "0.3.78"
 dependencies = [
  "anyhow",
  "askama",
@@ -5704,22 +5597,6 @@ dependencies = [
 
 [[package]]
 name = "tokio-tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edc5f74e248dc973e0dbb7b74c7e0d6fcc301c694ff50049504004ef4d0cdcd9"
-dependencies = [
- "futures-util",
- "log",
- "rustls",
- "rustls-pki-types",
- "tokio",
- "tokio-rustls",
- "tungstenite 0.24.0",
- "webpki-roots 0.26.11",
-]
-
-[[package]]
-name = "tokio-tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d25a406cddcc431a75d3d9afc6a7c0f7428d4891dd973e4d54c56b46127bf857"
@@ -5730,7 +5607,7 @@ dependencies = [
  "rustls-pki-types",
  "tokio",
  "tokio-rustls",
- "tungstenite 0.28.0",
+ "tungstenite",
  "webpki-roots 0.26.11",
 ]
 
@@ -5748,7 +5625,7 @@ dependencies = [
  "js-sys",
  "thiserror 2.0.18",
  "tokio",
- "tokio-tungstenite 0.28.0",
+ "tokio-tungstenite",
  "wasm-bindgen",
  "web-sys",
 ]
@@ -5846,7 +5723,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fec7c61a0695dc1887c1b53952990f3ad2e3a31453e1f49f10e75424943a93ec"
 dependencies = [
  "async-trait",
- "axum 0.8.8",
+ "axum",
  "base64",
  "bytes",
  "h2",
@@ -5881,7 +5758,7 @@ dependencies = [
 
 [[package]]
 name = "topology"
-version = "0.3.77"
+version = "0.3.78"
 dependencies = [
  "anyhow",
  "serde",
@@ -6039,26 +5916,6 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "tungstenite"
-version = "0.24.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "18e5b8366ee7a95b16d32197d0b2604b43a0be89dc5fac9f8e96ccafbaedda8a"
-dependencies = [
- "byteorder",
- "bytes",
- "data-encoding",
- "http",
- "httparse",
- "log",
- "rand 0.8.5",
- "rustls",
- "rustls-pki-types",
- "sha1",
- "thiserror 1.0.69",
- "utf-8",
-]
-
-[[package]]
-name = "tungstenite"
 version = "0.28.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8628dcc84e5a09eb3d8423d6cb682965dea9133204e8fb3efee74c2a0c259442"
@@ -6195,7 +6052,7 @@ dependencies = [
 
 [[package]]
 name = "validate"
-version = "0.3.77"
+version = "0.3.78"
 dependencies = [
  "anyhow",
  "shared",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,40 @@ exclude = ["crates/ebpf-redirect"]
 default-members = ["crates/client"]
 
 [workspace.dependencies]
+# Common application dependencies
+anyhow = "1.0.100"
+askama = "0.14.0"
+async-compression = { version = "0.4.32", features = ["tokio", "gzip"] }
+base64 = "0.22.1"
+bollard = "0.19.3"
+clap = { version = "4.5.16", features = ["derive"] }
+dirs = "6.0"
+futures = "0.3.31"
+futures-util = "0.3.31"
+ipnet = "2.11.0"
+jiff = { version = "0.2.20", features = ["serde"] }
+rand = "0.8.5"
+regex = "1"
+rpassword = "7.3"
+rustls = { version = "0.23", default-features = false, features = ["aws_lc_rs", "logging", "prefer-post-quantum", "std", "tls12"] }
+rustls-pemfile = "2.2"
+serde = "1.0.228"
+serde_derive = "1.0.228"
+serde_json = "1.0.128"
+ssh-key = { version = "0.6.7", features = ["rsa", "ed25519"] }
+strum = "0.27"
+tempfile = "3.25.0"
+tokio = "1.49.0"
+tokio-tungstenite = "0.28"
+tokio-util = "0.7"
+toml = "0.8.19"
+toml_edit = "0.22.22"
+tracing = "0.1"
+tracing-subscriber = "0.3"
+url = "2.5"
+uuid = { version = "1.11", features = ["v4", "serde"] }
+virt = { version = "0.4.1", features = ["qemu"] }
+
 # HTTP client
 reqwest = { version = "0.13.2", default-features = false, features = ["rustls"] }
 

--- a/crates/client/Cargo.toml
+++ b/crates/client/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sherpa"
-version = "0.3.77"
+version = "0.3.78"
 edition = "2024"
 
 [dependencies]
@@ -10,63 +10,63 @@ template = { path = "../template" }
 validate = { path = "../validate" }
 
 # Errors
-anyhow = "1.0.100"
+anyhow = { workspace = true }
 
 # CLI
-clap = { version = "4.5.16", features = ["derive", "env"] }
+clap = { workspace = true, features = ["env"] }
 
 # Serialization/Deserialization
-serde = "1.0.208"
-serde_derive = "1.0.208"
-serde_json = "1.0.128"
-toml = "0.8.19"
-toml_edit = "0.22.22"
+serde = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+toml_edit = { workspace = true }
 
 # De/Compression
-async-compression = { version = "0.4.32", features = ["tokio", "gzip"] }
+async-compression = { workspace = true }
 
 # Random number generator
-rand = "0.8.5"
+rand = { workspace = true }
 
 # Templates
-askama = "0.14.0"
+askama = { workspace = true }
 
 
 # Async
-tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread", "net", "time"] }
-futures = "0.3.31"
-futures-util = "0.3.31"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "time"] }
+futures = { workspace = true }
+futures-util = { workspace = true }
 
 # URL parsing
-url = "2.5"
+url = { workspace = true }
 
 # WebSocket client with TLS support
-tokio-tungstenite = { version = "0.24", features = ["rustls-tls-webpki-roots"] }
+tokio-tungstenite = { workspace = true, features = ["rustls-tls-webpki-roots"] }
 
 # UUID for RPC request IDs
-uuid = { version = "1.11", features = ["v4", "serde"] }
+uuid = { workspace = true }
 
 # Logging
-tracing = "0.1"
+tracing = { workspace = true }
 
 # Password input
-rpassword = "7.3"
+rpassword = { workspace = true }
 
 # Base64 decoding (for JWT)
-base64 = "0.22"
+base64 = { workspace = true }
 
 # Logging (subscriber for verbose mode)
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }
+tracing-subscriber = { workspace = true, features = ["env-filter"] }
 
 # Time/date handling
-jiff = { version = "0.2.20", features = ["serde"] }
+jiff = { workspace = true }
 
 # TLS support
-rustls = { version = "0.23", features = ["ring"] }
+rustls = { workspace = true }
 rustls-native-certs = "0.8"
 
 # Home directory detection
-dirs = "6.0"
+dirs = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { version = "0.61.2", features = [
@@ -77,4 +77,4 @@ windows-sys = { version = "0.61.2", features = [
 ] }
 
 [dev-dependencies]
-tempfile = "3.25.0"
+tempfile = { workspace = true }

--- a/crates/client/src/main.rs
+++ b/crates/client/src/main.rs
@@ -16,7 +16,7 @@ use std::process::ExitCode;
 async fn main() -> ExitCode {
     // Initialize rustls crypto provider (required for rustls 0.23+)
     // This must be done before any rustls operations
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
     match cmd::Cli::run().await {
         Ok(()) => ExitCode::from(0),

--- a/crates/client/src/ws_client/client.rs
+++ b/crates/client/src/ws_client/client.rs
@@ -123,7 +123,7 @@ impl RpcClient {
         tracing::debug!("Sending RPC request: {}", request_json);
 
         self.write
-            .send(Message::Text(request_json))
+            .send(Message::Text(request_json.into()))
             .await
             .context("Failed to send RPC request")?;
 
@@ -194,7 +194,7 @@ impl RpcClient {
         tracing::debug!("Sending streaming RPC request: {}", request_json);
 
         self.write
-            .send(Message::Text(request_json))
+            .send(Message::Text(request_json.into()))
             .await
             .context("Failed to send RPC request")?;
 

--- a/crates/container/Cargo.toml
+++ b/crates/container/Cargo.toml
@@ -1,26 +1,26 @@
 [package]
 name = "container"
-version = "0.3.77"
+version = "0.3.78"
 edition = "2024"
 
 [dependencies]
 shared = { path = "../shared" }
 
 # Errors
-anyhow = "1.0.100"
+anyhow = { workspace = true }
 
 # Logging
-tracing = "0.1"
+tracing = { workspace = true }
 
 # Containers
 # oci-client = "0.15"
-bollard = "0.19.3"
+bollard = { workspace = true }
 
 # De/Compression
-async-compression = { version = "0.4.32", features = ["tokio", "gzip"] }
+async-compression = { workspace = true }
 
 # Async
-tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread", "time", "fs", "io-util"] }
-tokio-util = { version = "0.7", features = ["codec"] }
-futures = "0.3.31"
-futures-util = "0.3.31"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "time", "fs", "io-util"] }
+tokio-util = { workspace = true, features = ["codec"] }
+futures = { workspace = true }
+futures-util = { workspace = true }

--- a/crates/db/Cargo.toml
+++ b/crates/db/Cargo.toml
@@ -1,23 +1,23 @@
 [package]
 name = "db"
-version = "0.3.77"
+version = "0.3.78"
 edition = "2024"
 
 [dependencies]
 shared = { path = "../shared" }
 
 # Errors
-anyhow = "1.0.100"
+anyhow = { workspace = true }
 
 # Networking
-ipnet = "2.11.0"
-jiff = { version = "0.2.20", features = ["serde"] }
+ipnet = { workspace = true }
+jiff = { workspace = true }
 
 # Logging
-tracing = "0.1"
+tracing = { workspace = true }
 
-serde = { version = "1.0.228", features = ["derive"] }
-serde_json = "1.0"
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true }
 surrealdb = "3.0.0"
 surrealdb-types = "3.0.0"
-tokio = { version = "1.49.0", features = ["macros", "rt-multi-thread"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }

--- a/crates/ebpf-redirect/Cargo.lock
+++ b/crates/ebpf-redirect/Cargo.lock
@@ -96,7 +96,7 @@ dependencies = [
 
 [[package]]
 name = "ebpf-redirect"
-version = "0.3.77"
+version = "0.3.78"
 dependencies = [
  "aya-ebpf",
 ]

--- a/crates/ebpf-redirect/Cargo.toml
+++ b/crates/ebpf-redirect/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ebpf-redirect"
-version = "0.3.77"
+version = "0.3.78"
 edition = "2021"
 
 [dependencies]

--- a/crates/libvirt/Cargo.toml
+++ b/crates/libvirt/Cargo.toml
@@ -1,19 +1,19 @@
 [package]
 name = "libvirt"
-version = "0.3.77"
+version = "0.3.78"
 edition = "2024"
 
 [dependencies]
 shared = { path = "../shared" }
 
 # Errors
-anyhow = "1.0.100"
+anyhow = { workspace = true }
 
 # Templates
-askama = "0.14.0"
+askama = { workspace = true }
 
 # Logging
-tracing = "0.1"
+tracing = { workspace = true }
 
 # Libvirt
-virt = { version = "0.4.1", features = ["qemu"] }
+virt = { workspace = true }

--- a/crates/network/Cargo.toml
+++ b/crates/network/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "network"
-version = "0.3.77"
+version = "0.3.78"
 edition = "2024"
 
 [dependencies]
 aya = "0.13.1"
 rtnetlink = "0.20.0"
 shared = { path = "../shared" }
-tokio = { version = "1", features = ["macros", "rt-multi-thread"] }
-futures = "0.3"
-anyhow = "1.0.100"
-tracing = "0.1"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+futures = { workspace = true }
+anyhow = { workspace = true }
+tracing = { workspace = true }

--- a/crates/server/Cargo.toml
+++ b/crates/server/Cargo.toml
@@ -1,13 +1,13 @@
 [package]
 name = "sherpad"
-version = "0.3.77"
+version = "0.3.78"
 edition = "2024"
 
 [dependencies]
 axum = { version = "0.8.8", features = ["ws", "multipart"] }
-tokio = { version = "1.0", features = ["macros", "rt-multi-thread", "net", "signal", "sync", "time", "fs", "io-util"] }
-tracing = "0.1"
-tracing-subscriber = { version = "0.3", features = ["env-filter", "time"] }
+tokio = { workspace = true, features = ["macros", "rt-multi-thread", "net", "signal", "sync", "time", "fs", "io-util"] }
+tracing = { workspace = true }
+tracing-subscriber = { workspace = true, features = ["env-filter", "time"] }
 time = "0.3"
 
 shared = { path = "../shared", features = ["netinfo"] }
@@ -20,47 +20,45 @@ validate = { path = "../validate" }
 db = { path = "../db" }
 
 # Errors
-anyhow = "1.0.100"
+anyhow = { workspace = true }
 
 # Process/Signal management
-nix = { version = "0.29", features = ["signal", "process"] }
+nix = { version = "0.30.1", features = ["signal", "process"] }
 
 # CLI
-clap = { version = "4.5.16", features = ["derive", "env"] }
+clap = { workspace = true, features = ["env"] }
 
 # Serialization/Deserialization
-serde = "1.0.208"
-serde_derive = "1.0.208"
-serde_json = "1.0.128"
-toml = "0.8.19"
-toml_edit = "0.22.22"
+serde = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
+toml = { workspace = true }
+toml_edit = { workspace = true }
 
 # Enum utilities
-strum = "0.27"
+strum = { workspace = true }
 
 # De/Compression
-async-compression = { version = "0.4.32", features = ["tokio", "gzip"] }
+async-compression = { workspace = true }
 zip = { version = "4", default-features = false, features = ["deflate"] }
 
 # Random number generator
-rand = "0.8.5"
+rand = { workspace = true }
 
 # Authentication
-jsonwebtoken = "9"
+jsonwebtoken = { version = "10.3", default-features = false, features = ["aws_lc_rs"] }
 
 # Templates
-askama = "0.14.0"
+askama = { workspace = true }
 
 
 # Async / Cancellation
-tokio-util = { version = "0.7", features = ["rt"] }
-futures = "0.3.31"
-futures-util = "0.3.31"
+tokio-util = { workspace = true, features = ["rt"] }
+futures = { workspace = true }
+futures-util = { workspace = true }
 async-stream = "0.3"
 
 # WebSocket support
-axum-extra = { version = "0.9", features = ["typed-header"] }
-tokio-tungstenite = "0.24"
 tower = "0.5"
 tower-http = { version = "0.6", features = ["trace", "cors"] }
 
@@ -68,36 +66,36 @@ tower-http = { version = "0.6", features = ["trace", "cors"] }
 rust-embed = "8"
 
 # UUID for connection IDs
-uuid = { version = "1.11", features = ["v4", "v7", "serde"] }
+uuid = { workspace = true, features = ["v7"] }
 
 # Concurrent collections
 dashmap = "6.1"
 
 # Timestamps for messages
-jiff = { version = "0.2.20", features = ["serde"] }
+jiff = { workspace = true }
 
 # http client
 reqwest = { workspace = true, features = ["stream"] }
 
 # Libvirt
-virt = { version = "0.4.1", features = ["qemu"] }
+virt = { workspace = true }
 
 # Docker
-bollard = "0.19.3"
+bollard = { workspace = true }
 
 # Regex
-regex = "1"
+regex = { workspace = true }
 
 # Generate SSH keys
-ssh-key = { version = "0.6.7", features = ["rsa", "ed25519"] }
+ssh-key = { workspace = true }
 
 # Password input
-rpassword = "7.3"
+rpassword = { workspace = true }
 
 # TLS support
 axum-server = { version = "0.7", features = ["tls-rustls"] }
-rustls = { version = "0.23", features = ["ring"] }
-rustls-pemfile = "2.2"
+rustls = { workspace = true }
+rustls-pemfile = { workspace = true }
 rcgen = "0.13"
 
 # OpenTelemetry
@@ -108,6 +106,6 @@ tracing-opentelemetry = { workspace = true }
 
 [dev-dependencies]
 tokio-test = "0.4"
-tempfile = "3.25.0"
-tokio-tungstenite = "0.24"
+tempfile = { workspace = true }
+tokio-tungstenite = { workspace = true }
 reqwest = { workspace = true, features = ["cookies", "form", "json"] }

--- a/crates/server/src/api/handlers.rs
+++ b/crates/server/src/api/handlers.rs
@@ -21,14 +21,14 @@ use crate::services::{
     resume, up,
 };
 use crate::templates::{
-    AdminImageUploadTemplate, AdminPasswordErrorTemplate, AdminPasswordSuccessTemplate,
-    AdminSshKeysListTemplate, AdminToolsTemplate, AdminUserEditTemplate, AdminUsersTemplate,
-    DashboardTemplate, EmptyStateTemplate, Error403Template, Error404Template, ErrorTemplate,
-    JobPageTemplate, LabCreateTemplate, LabDestroyButtonFragment, LabDestroyConfirmFragment,
-    LabDetailTemplate, LabsGridTemplate, LabsListTemplate, LoginErrorTemplate, LoginPageTemplate,
-    NodeDetailTemplate, NodesTableFragment, PasswordErrorTemplate, PasswordSuccessTemplate,
-    ProfileTemplate, SignupErrorTemplate, SignupPageTemplate, SshKeyErrorTemplate,
-    SshKeysListTemplate,
+    AdminImageUploadTemplate, AdminNotificationErrorTemplate, AdminPasswordErrorTemplate,
+    AdminPasswordSuccessTemplate, AdminSshKeysListTemplate, AdminToolsTemplate,
+    AdminUserEditTemplate, AdminUsersTemplate, DashboardTemplate, EmptyStateTemplate,
+    Error403Template, Error404Template, ErrorTemplate, JobPageTemplate, LabCreateTemplate,
+    LabDestroyButtonFragment, LabDestroyConfirmFragment, LabDetailTemplate, LabsGridTemplate,
+    LabsListTemplate, LoginErrorTemplate, LoginPageTemplate, NodeDetailTemplate,
+    NodesTableFragment, PasswordErrorTemplate, PasswordSuccessTemplate, ProfileTemplate,
+    SignupErrorTemplate, SignupPageTemplate, SshKeyErrorTemplate, SshKeysListTemplate,
 };
 
 use super::errors::ApiError;
@@ -2517,10 +2517,13 @@ pub async fn admin_image_update_handler(
                 "Cannot unset default - only one default exists for {}",
                 params.model
             );
-            return Ok(Html(format!(
-                r#"<div class="notification-error">Cannot unset default - at least one version must be marked as default for {}</div>"#,
-                params.model
-            )).into_response());
+            return Ok(AdminNotificationErrorTemplate {
+                message: format!(
+                    "Cannot unset default - at least one version must be marked as default for {}",
+                    params.model
+                ),
+            }
+            .into_response());
         }
     }
 
@@ -2539,7 +2542,10 @@ pub async fn admin_image_update_handler(
         &form.interface_prefix,
     ) {
         tracing::warn!("Node config validation failed: {:?}", e);
-        return Ok(Html(format!(r#"<div class="notification-error">{}</div>"#, e)).into_response());
+        return Ok(AdminNotificationErrorTemplate {
+            message: e.to_string(),
+        }
+        .into_response());
     }
 
     // Create updated config (keeping id, model, kind, management_interface from existing)
@@ -2785,9 +2791,7 @@ pub async fn admin_image_upload_handler(
         Ok(f) => f,
         Err(e) => {
             tracing::warn!("Upload form validation failed: {}", e);
-            return Ok(
-                Html(format!(r#"<div class="notification-error">{}</div>"#, e)).into_response(),
-            );
+            return Ok(AdminNotificationErrorTemplate { message: e }.into_response());
         }
     };
 
@@ -2803,10 +2807,9 @@ pub async fn admin_image_upload_handler(
 
     if let Err(e) = tokio::fs::write(&temp_file, &fields.file_data).await {
         tracing::error!("Failed to write temp file {}: {:?}", temp_path, e);
-        return Ok(Html(format!(
-            r#"<div class="notification-error">Failed to save uploaded file: {}</div>"#,
-            e
-        ))
+        return Ok(AdminNotificationErrorTemplate {
+            message: format!("Failed to save uploaded file: {}", e),
+        }
         .into_response());
     }
 
@@ -2847,10 +2850,9 @@ pub async fn admin_image_upload_handler(
         }
         Err(e) => {
             tracing::error!("Image upload failed: {:?}", e);
-            Ok(Html(format!(
-                r#"<div class="notification-error">Import failed: {}</div>"#,
-                e
-            ))
+            Ok(AdminNotificationErrorTemplate {
+                message: format!("Import failed: {}", e),
+            }
             .into_response())
         }
     }

--- a/crates/server/src/main.rs
+++ b/crates/server/src/main.rs
@@ -12,7 +12,7 @@ use sherpad::daemon::manager::{
 async fn main() -> Result<()> {
     // Initialize rustls crypto provider (required for rustls 0.23+)
     // This must be done before any rustls operations
-    let _ = rustls::crypto::ring::default_provider().install_default();
+    let _ = rustls::crypto::aws_lc_rs::default_provider().install_default();
 
     // Check if we're being spawned as a background child
     let args: Vec<String> = std::env::args().collect();

--- a/crates/server/src/templates.rs
+++ b/crates/server/src/templates.rs
@@ -738,7 +738,7 @@ impl IntoResponse for AdminImageUploadTemplate {
 
 /// Error notification returned by admin image form requests.
 #[derive(Template)]
-#[template(path = "admin/partials/notification-error.html.jinja")]
+#[template(path = "admin/partials/notification-error.html.jinja", escape = "html")]
 pub struct AdminNotificationErrorTemplate {
     pub message: String,
 }
@@ -1173,7 +1173,7 @@ mod tests {
         };
         let html = tpl.render().expect("template should render");
 
-        assert!(html.contains("Invalid &lt;script&gt;"));
+        assert!(html.contains("Invalid &#60;script&#62;"));
         assert!(!html.contains("<script>"));
     }
 

--- a/crates/server/src/templates.rs
+++ b/crates/server/src/templates.rs
@@ -736,6 +736,26 @@ impl IntoResponse for AdminImageUploadTemplate {
     }
 }
 
+/// Error notification returned by admin image form requests.
+#[derive(Template)]
+#[template(path = "admin/partials/notification-error.html.jinja")]
+pub struct AdminNotificationErrorTemplate {
+    pub message: String,
+}
+
+impl IntoResponse for AdminNotificationErrorTemplate {
+    fn into_response(self) -> Response {
+        match self.render() {
+            Ok(html) => Html(html).into_response(),
+            Err(err) => (
+                StatusCode::INTERNAL_SERVER_ERROR,
+                format!("Failed to render template: {}", err),
+            )
+                .into_response(),
+        }
+    }
+}
+
 // ============================================================================
 // Admin Tools Templates
 // ============================================================================
@@ -1144,6 +1164,17 @@ mod tests {
         };
         let html = tpl.render().expect("template should render");
         assert!(html.contains("Invalid credentials"));
+    }
+
+    #[test]
+    fn test_admin_notification_error_template_escapes_message() {
+        let tpl = AdminNotificationErrorTemplate {
+            message: "Invalid <script>alert('unsafe')</script>".to_string(),
+        };
+        let html = tpl.render().expect("template should render");
+
+        assert!(html.contains("Invalid &lt;script&gt;"));
+        assert!(!html.contains("<script>"));
     }
 
     #[test]

--- a/crates/server/templates/admin/partials/notification-error.html.jinja
+++ b/crates/server/templates/admin/partials/notification-error.html.jinja
@@ -1,0 +1,3 @@
+<div class="p-4 rounded-md mb-4 text-sm font-medium bg-alert-error text-alert-error-text border border-alert-error-border" role="alert">
+    {{ message }}
+</div>

--- a/crates/shared/Cargo.toml
+++ b/crates/shared/Cargo.toml
@@ -1,81 +1,81 @@
 [package]
 name = "shared"
-version = "0.3.77"
+version = "0.3.78"
 edition = "2024"
 
 [dependencies]
-toml = "0.8.19"
+toml = { workspace = true }
 
 # File system
 shellexpand = "3.1.0"
 
 # Errors
-anyhow = "1.0.100"
+anyhow = { workspace = true }
 thiserror = "2.0.17"
 
 # Logging
-tracing = "0.1"
+tracing = { workspace = true }
 
 # Encoding/decoding
-base64 = "0.22.1"
+base64 = { workspace = true }
 md5 = "0.7.0"
 sha2 = "0.10.8"
 twox-hash = "2.0.0"
 
 # Generate SSH keys
-ssh-key = { version = "0.6.7", features = ["rsa", "ed25519"] }
+ssh-key = { workspace = true }
 
 # Random number generator
-rand = "0.8.5"
+rand = { workspace = true }
 petname = "2.0.2"
 
 # Authentication
 argon2 = "0.5"
-regex = "1"
-jiff = { version = "0.2.20", features = ["serde"] }
+regex = { workspace = true }
+jiff = { workspace = true }
 
 # IP Addressing
-ipnet = { version = "2.11.0", features = ["serde"] }
+ipnet = { workspace = true, features = ["serde"] }
 getifaddrs = { version = "0.6.0", optional = true }
 
 # Home directory detection
-dirs = "6.0"
+dirs = { workspace = true }
 
 reqwest = { workspace = true }
 
 # TLS support
-rustls = { version = "0.23", features = ["ring"] }
+rustls = { workspace = true }
 rustls-pki-types = "1.10"
 webpki-roots = "0.26"
-rustls-pemfile = "2.2"
+rustls-pemfile = { workspace = true }
 
 # Certificate parsing
 x509-parser = "0.16"
 hex = "0.4"
-url = "2.5"
+url = { workspace = true }
 
 # Templates
-askama = "0.14.0"
+askama = { workspace = true }
 
 # Table formatting
 tabled = "0.20.0"
 
 # CLI
-clap = { version = "4.5.16", features = ["derive"] }
+clap = { workspace = true }
 
 # Serialization/Deserialization
-serde = "1.0.208"
-serde_derive = "1.0.208"
-serde_json = "1.0.128"
+serde = { workspace = true }
+serde_derive = { workspace = true }
+serde_json = { workspace = true }
 schemars = "1.2.1"
 
 # Enum helpers
-strum = "0.27"
+strum = { workspace = true }
 strum_macros = "0.27"
 
 [dev-dependencies]
-tokio = { version = "1.40.0", features = ["macros", "rt-multi-thread"] }
-tempfile = "3.25.0"
+tokio = { workspace = true, features = ["macros", "rt-multi-thread"] }
+tempfile = { workspace = true }
 
 [features]
 netinfo = ["dep:getifaddrs"]

--- a/crates/shared/src/tls/config.rs
+++ b/crates/shared/src/tls/config.rs
@@ -310,7 +310,7 @@ mod tests {
 
     #[test]
     fn test_build_insecure_config() {
-        rustls::crypto::ring::default_provider()
+        rustls::crypto::aws_lc_rs::default_provider()
             .install_default()
             .ok();
 
@@ -330,7 +330,7 @@ mod tests {
 
     #[test]
     fn test_build_with_system_certs() {
-        rustls::crypto::ring::default_provider()
+        rustls::crypto::aws_lc_rs::default_provider()
             .install_default()
             .ok();
 

--- a/crates/template/Cargo.toml
+++ b/crates/template/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "template"
-version = "0.3.77"
+version = "0.3.78"
 edition = "2024"
 
 [dependencies]
@@ -8,15 +8,15 @@ shared = { path = "../shared" }
 topology = { path = "../topology" }
 
 # Templates
-anyhow = "1.0.100"
-askama = "0.14.0"
-serde = "1.0.208"
-serde_derive = "1.0.208"
+anyhow = { workspace = true }
+askama = { workspace = true }
+serde = { workspace = true }
+serde_derive = { workspace = true }
 serde_yaml = "0.9.34"
-serde_json = "1.0.128"
+serde_json = { workspace = true }
 
 # IP Addressing
-ipnet = "2.11.0"
+ipnet = { workspace = true }
 
 [dev-dependencies]
 urlencoding = "2.1"

--- a/crates/topology/Cargo.toml
+++ b/crates/topology/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "topology"
-version = "0.3.77"
+version = "0.3.78"
 edition = "2024"
 
 [dependencies]
 shared = { path = "../shared" }
 
 # Errors
-anyhow = "1.0.100"
+anyhow = { workspace = true }
 
 # Se/Deserialzation
-serde = "1.0.208"
-serde_derive = "1.0.208"
-toml = "0.8.19"
-toml_edit = "0.22.22"
+serde = { workspace = true }
+serde_derive = { workspace = true }
+toml = { workspace = true }
+toml_edit = { workspace = true }

--- a/crates/validate/Cargo.toml
+++ b/crates/validate/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "validate"
-version = "0.3.77"
+version = "0.3.78"
 edition = "2024"
 
 [dependencies]
@@ -8,7 +8,7 @@ shared = { path = "../shared" }
 topology = { path = "../topology" }
 
 # Errors
-anyhow = "1.0.100"
+anyhow = { workspace = true }
 
 # Logging
-tracing = "0.1"
+tracing = { workspace = true }


### PR DESCRIPTION
## Summary

- centralize common crate dependencies at workspace level
- remove duplicate Axum, WebSocket, JWT, and Nix dependency versions
- standardize Rustls on AWS-LC
- bump every crate to v0.3.78
- enforce HTML escaping for admin error notifications

## Compile-time benchmark

- before: 287.41 seconds
- after: 279.73 seconds
- improvement: 7.68 seconds (2.7%)

SurrealDB remains the dominant compilation cost.

## Validation

- cargo fmt
- cargo clippy --workspace -- -D warnings
- cargo llvm-cov nextest --workspace
- 731 selected tests passed